### PR TITLE
Update to 2020 Scrum Guide with Markdown formatting

### DIFF
--- a/scrum guide
+++ b/scrum guide
@@ -3,371 +3,301 @@
 The Definitive Guide to Scrum:
 The Rules of the Game
 
-November 2017
+November 2020
 
 Developed and sustained by Scrum creators: Ken Schwaber and Jeff Sutherland
 
 ## Purpose of the Scrum Guide
 
-Scrum is a framework for developing, delivering, and sustaining complex products. This Guide contains the definition of Scrum. This definition consists of Scrum’s roles, events, artifacts, and the rules that bind them together. Ken Schwaber and Jeff Sutherland developed Scrum; the Scrum Guide is written and provided by them. Together, they stand behind the Scrum Guide.
+We developed Scrum in the early 1990s. We wrote the first version of the Scrum Guide in 2010 to help people worldwide understand Scrum. We have evolved the Guide since then through small, functional updates. Together, we stand behind it.
 
-## Definition of Scrum
+The Scrum Guide contains the definition of Scrum. Each element of the framework serves a specific purpose that is essential to the overall value and results realized with Scrum. Changing the core design or ideas of Scrum, leaving out elements, or not following the rules of Scrum, covers up problems and limits the benefits of Scrum, potentially even rendering it useless.
 
-Scrum (n): A framework within which people can address complex adaptive problems, while productively and creatively delivering products of the highest possible value.
+We follow the growing use of Scrum within an ever-growing complex world. We are humbled to see Scrum being adopted in many domains holding essentially complex work, beyond software product development where Scrum has its roots. As Scrum’s use spreads, developers, researchers, analysts, scientists, and other specialists do the work. We use the word “developers” in Scrum not to exclude, but to simplify. If you get value from Scrum, consider yourself included.
 
-Scrum is:
+As Scrum is being used, patterns, processes, and insights that fit the Scrum framework as described in this document, may be found, applied and devised. Their description is beyond the purpose of the Scrum Guide because they are context sensitive and differ widely between Scrum uses. Such tactics for using within the Scrum framework vary widely and are described elsewhere.
 
-- Lightweight
-- Simple to understand
-- Difficult to master
+## Scrum Definition
 
-Scrum is a process framework that has been used to manage work on complex products since the early 1990s. Scrum is not a process, technique, or definitive method. Rather, it is a framework within which you can employ various processes and techniques. Scrum makes clear the relative efficacy of your product management and work techniques so that you can continuously improve the product, the team, and the working environment.
+Scrum is a lightweight framework that helps people, teams and organizations generate value through adaptive solutions for complex problems.
 
-The Scrum framework consists of Scrum Teams and their associated roles, events, artifacts, and rules. Each component within the framework serves a specific purpose and is essential to Scrum’s success and usage.
+In a nutshell, Scrum requires a Scrum Master to foster an environment where:
 
-The rules of Scrum bind together the roles, events, and artifacts, governing the relationships and interaction between them. The rules of Scrum are described throughout the body of this document.
+1. A Product Owner orders the work for a complex problem into a Product Backlog.
+2. The Scrum Team turns a selection of the work into an Increment of value during a Sprint.
+3. The Scrum Team and its stakeholders inspect the results and adjust for the next Sprint.
+4. _Repeat_
 
-Specific tactics for using the Scrum framework vary and are described elsewhere.
+Scrum is simple. Try it as is and determine if its philosophy, theory, and structure help to achieve goals and create value. The Scrum framework is purposefully incomplete, only defining the parts required to implement Scrum theory. Scrum is built upon by the collective intelligence of the people using it. Rather than provide people with detailed instructions, the rules of Scrum guide their relationships and interactions.
 
-## Uses of Scrum
-
-Scrum was initially developed for managing and developing products. Starting in the early 1990s, Scrum has been used extensively, worldwide, to:
-
-1. Research and identify viable markets, technologies, and product capabilities;
-2. Develop products and enhancements;
-3. Release products and enhancements, as frequently as many times per day;
-4. Develop and sustain Cloud (online, secure, on-demand) and other operational environments for product use; and,
-5. Sustain and renew products.
-
-Scrum has been used to develop software, hardware, embedded software, networks of interacting function, autonomous vehicles, schools, government, marketing, managing the operation of organizations and almost everything we use in our daily lives, as individuals and societies.
-
-As technology, market, and environmental complexities and their interactions have rapidly increased, Scrum’s utility in dealing with complexity is proven daily.
-
-Scrum proved especially effective in iterative and incremental knowledge transfer. Scrum is now widely used for products, services, and the management of the parent organization.
-
-The essence of Scrum is a small team of people. The individual team is highly flexible and adaptive. These strengths continue operating in single, several, many, and networks of teams that develop, release, operate and sustain the work and work products of thousands of people. They collaborate and interoperate through sophisticated development architectures and target release environments.
-
-When the words "develop" and "development" are used in the Scrum Guide, they refer to complex work, such as those types identified above.
+Various processes, techniques and methods can be employed within the framework. Scrum wraps around existing practices or renders them unnecessary. Scrum makes visible the relative efficacy of current management, environment, and work techniques, so that improvements can be made.
 
 ## Scrum Theory
 
-Scrum is founded on empirical process control theory, or empiricism. Empiricism asserts that knowledge comes from experience and making decisions based on what is known. Scrum employs an iterative, incremental approach to optimize predictability and control risk. Three pillars uphold every implementation of empirical process control: transparency, inspection, and adaptation.
+Scrum is founded on empiricism and lean thinking. Empiricism asserts that knowledge comes from experience and making decisions based on what is observed. Lean thinking reduces waste and focuses on the essentials.
+
+Scrum employs an iterative, incremental approach to optimize predictability and to control risk. Scrum engages groups of people who collectively have all the skills and expertise to do the work and share or acquire such skills as needed.
+
+Scrum combines four formal events for inspection and adaptation within a containing event, the Sprint. These events work because they implement the empirical Scrum pillars of transparency, inspection, and adaptation.
 
 ### Transparency
 
-Significant aspects of the process must be visible to those responsible for the outcome. Transparency requires those aspects be defined by a common standard so observers share a common understanding of what is being seen.
+The emergent process and work must be visible to those performing the work as well as those receiving the work. With Scrum, important decisions are based on the perceived state of its three formal artifacts. Artifacts that have low transparency can lead to decisions that diminish value and increase risk.
 
-For example:
+Transparency enables inspection. Inspection without transparency is misleading and wasteful.
 
-A common language referring to the process must be shared by all participants; and,
-Those performing the work and those inspecting the resulting increment must share a common definition of "Done".
-Inspection
-Scrum users must frequently inspect Scrum artifacts and progress toward a Sprint Goal to detect undesirable variances. Their inspection should not be so frequent that inspection gets in the way of the work. Inspections are most beneficial when diligently performed by skilled inspectors at the point of work.
+### Inspection
+
+The Scrum artifacts and the progress toward agreed goals must be inspected frequently and diligently to detect potentially undesirable variances or problems. To help with inspection, Scrum provides cadence in the form of its five events.
+
+Inspection enables adaptation. Inspection without adaptation is considered pointless. Scrum events are designed to provoke change.
 
 ### Adaptation
 
-If an inspector determines that one or more aspects of a process deviate outside acceptable limits, and that the resulting product will be unacceptable, the process or the material being processed must be adjusted. An adjustment must be made as soon as possible to minimize further deviation.
+If any aspects of a process deviate outside acceptable limits or if the resulting product is unacceptable, the process being applied or the materials being produced must be adjusted. The adjustment must be made as soon as possible to minimize further deviation.
 
-Scrum prescribes four formal events for inspection and adaptation, as described in the Scrum Events section of this document:
-
-- Sprint Planning
-- Daily Scrum
-- Sprint Review
-- Sprint Retrospective
+Adaptation becomes more difficult when the people involved are not empowered or self-managing. A Scrum Team is expected to adapt the moment it learns anything new through inspection.
 
 ## Scrum Values
 
-When the values of commitment, courage, focus, openness and respect are embodied and lived by the Scrum Team, the Scrum pillars of transparency, inspection, and adaptation come to life and build trust for everyone. The Scrum Team members learn and explore those values as they work with the Scrum events, roles and artifacts.
+Successful use of Scrum depends on people becoming more proficient in living five values:
 
-Successful use of Scrum depends on people becoming more proficient in living these five values. People personally commit to achieving the goals of the Scrum Team. The Scrum Team members have courage to do the right thing and work on tough problems. Everyone focuses on the work of the Sprint and the goals of the Scrum Team. The Scrum Team and its stakeholders agree to be open about all the work and the challenges with performing the work. Scrum Team members respect each other to be capable, independent people.
+***Commitment, Focus, Openness, Respect, and Courage***
 
-## The Scrum Team
+The Scrum Team commits to achieving its goals and to supporting each other. Their primary focus is on the work of the Sprint to make the best possible progress toward these goals. The Scrum Team and its stakeholders are open about the work and the challenges. Scrum Team members respect each other to be capable, independent people, and are respected as such by the people with whom they work. The Scrum Team members have the courage to do the right thing, to work on tough problems.
 
-The Scrum Team consists of a Product Owner, the Development Team, and a Scrum Master. Scrum Teams are self-organizing and cross-functional. Self-organizing teams choose how best to accomplish their work, rather than being directed by others outside the team. Cross-functional teams have all competencies needed to accomplish the work without depending on others not part of the team. The team model in Scrum is designed to optimize flexibility, creativity, and productivity. The Scrum Team has proven itself to be increasingly effective for all the earlier stated uses, and any complex work.
+These values give direction to the Scrum Team with regard to their work, actions, and behavior. The decisions that are made, the steps taken, and the way Scrum is used should reinforce these values, not diminish or undermine them. The Scrum Team members learn and explore the values as they work with the Scrum events and artifacts. When these values are embodied by the Scrum Team and the people they work with, the empirical Scrum pillars of transparency, inspection, and adaptation come to life building trust.
 
-Scrum Teams deliver products iteratively and incrementally, maximizing opportunities for feedback. Incremental deliveries of "Done" product ensure a potentially useful version of working product is always available.
+## Scrum Team
 
-### The Product Owner
+The fundamental unit of Scrum is a small team of people, a Scrum Team. The Scrum Team consists of one Scrum Master, one Product Owner, and Developers. Within a Scrum Team, there are no sub-teams or hierarchies. It is a cohesive unit of professionals focused on one objective at a time, the Product Goal.
 
-The Product Owner is responsible for maximizing the value of the product resulting from work of the Development Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.
+Scrum Teams are cross-functional, meaning the members have all the skills necessary to create value each Sprint. They are also self-managing, meaning they internally decide who does what, when, and how.
 
-The Product Owner is the sole person responsible for managing the Product Backlog. Product Backlog management includes:
+The Scrum Team is small enough to remain nimble and large enough to complete significant work within a Sprint, typically 10 or fewer people. In general, we have found that smaller teams communicate better and are more productive. If Scrum Teams become too large, they should consider reorganizing into multiple cohesive Scrum Teams, each focused on the same product. Therefore, they should share the same Product Goal, Product Backlog, and Product Owner.
 
-- Clearly expressing Product Backlog items;
-- Ordering the items in the Product Backlog to best achieve goals and missions;
-- Optimizing the value of the work the Development Team performs;
-- Ensuring that the Product Backlog is visible, transparent, and clear to all, and shows what the Scrum Team will work on next; and,
-- Ensuring the Development Team understands items in the Product Backlog to the level needed.
+The Scrum Team is responsible for all product-related activities from stakeholder collaboration, verification, maintenance, operation, experimentation, research and development, and anything else that might be required. They are structured and empowered by the organization to manage their own work. Working in Sprints at a sustainable pace improves the Scrum Team’s focus and consistency.
 
-The Product Owner may do the above work, or have the Development Team do it. However, the Product Owner remains accountable.
+The entire Scrum Team is accountable for creating a valuable, useful Increment every Sprint. Scrum defines three specific accountabilities within the Scrum Team: the Developers, the Product Owner, and the Scrum Master.
 
-The Product Owner is one person, not a committee. The Product Owner may represent the desires of a committee in the Product Backlog, but those wanting to change a Product Backlog item’s priority must address the Product Owner.
+### Developers
 
-For the Product Owner to succeed, the entire organization must respect his or her decisions. The Product Owner’s decisions are visible in the content and ordering of the Product Backlog. No one can force the Development Team to work from a different set of requirements.
+Developers are the people in the Scrum Team that are committed to creating any aspect of a usable Increment each Sprint.
 
-### The Development Team
+The specific skills needed by the Developers are often broad and will vary with the domain of work. However, the Developers are always accountable for:
 
-The Development Team consists of professionals who do the work of delivering a potentially releasable Increment of "Done" product at the end of each Sprint. A "Done" increment is required at the Sprint Review. Only members of the Development Team create the Increment.
+- Creating a plan for the Sprint, the Sprint Backlog;
+- Instilling quality by adhering to a Definition of Done;
+- Adapting their plan each day toward the Sprint Goal; and,
+- Holding each other accountable as professionals.
 
-Development Teams are structured and empowered by the organization to organize and manage their own work. The resulting synergy optimizes the Development Team’s overall efficiency and effectiveness.
+### Product Owner
 
-Development Teams have the following characteristics:
+The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.
 
-- They are self-organizing. No one (not even the Scrum Master) tells the Development Team how to turn Product Backlog into Increments of potentially releasable functionality;
-- Development Teams are cross-functional, with all the skills as a team necessary to create a product Increment;
-- Scrum recognizes no titles for Development Team members, regardless of the work being performed by the person;
-- Scrum recognizes no sub-teams in the Development Team, regardless of domains that need to be addressed like testing, architecture, operations, or business analysis; and,
-- Individual Development Team members may have specialized skills and areas of focus, but accountability belongs to the Development Team as a whole.
+The Product Owner is also accountable for effective Product Backlog management, which includes:
 
-#### Development Team Size
+- Developing and explicitly communicating the Product Goal;
+- Creating and clearly communicating Product Backlog items;
+- Ordering Product Backlog items; and,
+- Ensuring that the Product Backlog is transparent, visible and understood.
 
-Optimal Development Team size is small enough to remain nimble and large enough to complete significant work within a Sprint. Fewer than three Development Team members decrease interaction and results in smaller productivity gains. Smaller Development Teams may encounter skill constraints during the Sprint, causing the Development Team to be unable to deliver a potentially releasable Increment. Having more than nine members requires too much coordination. Large Development Teams generate too much complexity for an empirical process to be useful. The Product Owner and Scrum Master roles are not included in this count unless they are also executing the work of the Sprint Backlog.
+The Product Owner may do the above work or may delegate the responsibility to others. Regardless, the Product Owner remains accountable.
 
-### The Scrum Master
+For Product Owners to succeed, the entire organization must respect their decisions. These decisions are visible in the content and ordering of the Product Backlog, and through the inspectable Increment at the Sprint Review.
 
-The Scrum Master is responsible for promoting and supporting Scrum as defined in the Scrum Guide. Scrum Masters do this by helping everyone understand Scrum theory, practices, rules, and values.
+The Product Owner is one person, not a committee. The Product Owner may represent the needs of many stakeholders in the Product Backlog. Those wanting to change the Product Backlog can do so by trying to convince the Product Owner.
 
-The Scrum Master is a servant-leader for the Scrum Team. The Scrum Master helps those outside the Scrum Team understand which of their interactions with the Scrum Team are helpful and which aren’t. The Scrum Master helps everyone change these interactions to maximize the value created by the Scrum Team.
+### Scrum Master
 
-#### Scrum Master Service to the Product Owner
+The Scrum Master is accountable for establishing Scrum as defined in the Scrum Guide. They do this by helping everyone understand Scrum theory and practice, both within the Scrum Team and the organization.
+
+The Scrum Master is accountable for the Scrum Team’s effectiveness. They do this by enabling the Scrum Team to improve its practices, within the Scrum framework.
+
+Scrum Masters are true leaders who serve the Scrum Team and the larger organization.
+
+The Scrum Master serves the Scrum Team in several ways, including:
+
+- Coaching the team members in self-management and cross-functionality;
+- Helping the Scrum Team focus on creating high-value Increments that meet the Definition of Done;
+- Causing the removal of impediments to the Scrum Team’s progress; and,
+- Ensuring that all Scrum events take place and are positive, productive, and kept within the timebox.
 
 The Scrum Master serves the Product Owner in several ways, including:
 
-- Ensuring that goals, scope, and product domain are understood by everyone on the Scrum Team as well as possible;
-- Finding techniques for effective Product Backlog management;
+- Helping find techniques for effective Product Goal definition and Product Backlog management;
 - Helping the Scrum Team understand the need for clear and concise Product Backlog items;
-- Understanding product planning in an empirical environment;
-- Ensuring the Product Owner knows how to arrange the Product Backlog to maximize value;
-- Understanding and practicing agility; and,
-- Facilitating Scrum events as requested or needed.
-
-#### Scrum Master Service to the Development Team
-
-The Scrum Master serves the Development Team in several ways, including:
-
-- Coaching the Development Team in self-organization and cross-functionality;
-- Helping the Development Team to create high-value products;
-- Removing impediments to the Development Team’s progress;
-- Facilitating Scrum events as requested or needed; and,
-- Coaching the Development Team in organizational environments in which Scrum is not yet fully adopted and understood.
-
-#### Scrum Master Service to the Organization
+- Helping establish empirical product planning for a complex environment; and,
+- Facilitating stakeholder collaboration as requested or needed.
 
 The Scrum Master serves the organization in several ways, including:
 
-- Leading and coaching the organization in its Scrum adoption;
-- Planning Scrum implementations within the organization;
-- Helping employees and stakeholders understand and enact Scrum and empirical product development;
-- Causing change that increases the productivity of the Scrum Team; and,
-- Working with other Scrum Masters to increase the effectiveness of the application of Scrum in the organization.
+- Leading, training, and coaching the organization in its Scrum adoption;
+- Planning and advising Scrum implementations within the organization;
+- Helping employees and stakeholders understand and enact an empirical approach for complex work; and,
+- Removing barriers between stakeholders and Scrum Teams.
 
 ## Scrum Events
 
-Prescribed events are used in Scrum to create regularity and to minimize the need for meetings not defined in Scrum. All events are time-boxed events, such that every event has a maximum duration. Once a Sprint begins, its duration is fixed and cannot be shortened or lengthened. The remaining events may end whenever the purpose of the event is achieved, ensuring an appropriate amount of time is spent without allowing waste in the process.
+The Sprint is a container for all other events. Each event in Scrum is a formal opportunity to inspect and adapt Scrum artifacts. These events are specifically designed to enable the transparency required. Failure to operate any events as prescribed results in lost opportunities to inspect and adapt. Events are used in Scrum to create regularity and to minimize the need for meetings not defined in Scrum.
 
-Other than the Sprint itself, which is a container for all other events, each event in Scrum is a formal opportunity to inspect and adapt something. These events are specifically designed to enable critical transparency and inspection. Failure to include any of these events results in reduced transparency and is a lost opportunity to inspect and adapt.
+Optimally, all events are held at the same time and place to reduce complexity.
 
 ### The Sprint
-The heart of Scrum is a Sprint, a time-box of one month or less during which a "Done", useable, and potentially releasable product Increment is created. Sprints have consistent durations throughout a development effort. A new Sprint starts immediately after the conclusion of the previous Sprint.
 
-Sprints contain and consist of the Sprint Planning, Daily Scrums, the development work, the Sprint Review, and the Sprint Retrospective.
+Sprints are the heartbeat of Scrum, where ideas are turned into value.
+
+They are fixed length events of one month or less to create consistency. A new Sprint starts immediately after the conclusion of the previous Sprint.
+
+All the work necessary to achieve the Product Goal, including Sprint Planning, Daily Scrums, Sprint Review, and Sprint Retrospective, happen within Sprints.
 
 During the Sprint:
 
 - No changes are made that would endanger the Sprint Goal;
-- Quality goals do not decrease; and,
-- Scope may be clarified and re-negotiated between the Product Owner and Development Team as more is learned.
+- Quality does not decrease;
+- The Product Backlog is refined as needed; and,
+- Scope may be clarified and renegotiated with the Product Owner as more is learned.
 
-Each Sprint may be considered a project with no more than a one-month horizon. Like projects, Sprints are used to accomplish something. Each Sprint has a goal of what is to be built, a design and flexible plan that will guide building it, the work, and the resultant product increment.
+Sprints enable predictability by ensuring inspection and adaptation of progress toward a Product Goal at least every calendar month. When a Sprint’s horizon is too long the Sprint Goal may become invalid, complexity may rise, and risk may increase. Shorter Sprints can be employed to generate more learning cycles and limit risk of cost and effort to a smaller time frame. Each Sprint may be considered a short project.
 
-Sprints are limited to one calendar month. When a Sprint’s horizon is too long the definition of what is being built may change, complexity may rise, and risk may increase. Sprints enable predictability by ensuring inspection and adaptation of progress toward a Sprint Goal at least every calendar month. Sprints also limit risk to one calendar month of cost.
+Various practices exist to forecast progress, like burn-downs, burn-ups, or cumulative flows. While proven useful, these do not replace the importance of empiricism. In complex environments, what will happen is unknown. Only what has already happened may be used for forward-looking decision making.
 
-#### Cancelling a Sprint
-
-A Sprint can be cancelled before the Sprint time-box is over. Only the Product Owner has the authority to cancel the Sprint, although he or she may do so under influence from the stakeholders, the Development Team, or the Scrum Master.
-
-A Sprint would be cancelled if the Sprint Goal becomes obsolete. This might occur if the company changes direction or if market or technology conditions change. In general, a Sprint should be cancelled if it no longer makes sense given the circumstances. But, due to the short duration of Sprints, cancellation rarely makes sense.
-
-When a Sprint is cancelled, any completed and "Done" Product Backlog items are reviewed. If part of the work is potentially releasable, the Product Owner typically accepts it. All incomplete Product Backlog Items are re-estimated and put back on the Product Backlog. The work done on them depreciates quickly and must be frequently re-estimated.
-
-Sprint cancellations consume resources, since everyone regroups in another Sprint Planning to start another Sprint. Sprint cancellations are often traumatic to the Scrum Team, and are very uncommon.
+A Sprint could be cancelled if the Sprint Goal becomes obsolete. Only the Product Owner has the authority to cancel the Sprint.
 
 ### Sprint Planning
 
-The work to be performed in the Sprint is planned at the Sprint Planning. This plan is created by the collaborative work of the entire Scrum Team.
+Sprint Planning initiates the Sprint by laying out the work to be performed for the Sprint. This resulting plan is created by the collaborative work of the entire Scrum Team.
 
-Sprint Planning is time-boxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and that attendants understand its purpose. The Scrum Master teaches the Scrum Team to keep it within the time-box.
+The Product Owner ensures that attendees are prepared to discuss the most important Product Backlog items and how they map to the Product Goal. The Scrum Team may also invite other people to attend Sprint Planning to provide advice.
 
-Sprint Planning answers the following:
+Sprint Planning addresses the following topics:
 
-- What can be delivered in the Increment resulting from the upcoming Sprint?
-- How will the work needed to deliver the Increment be achieved?
+#### Topic One: Why is this Sprint valuable?
 
-####Topic One: What can be done this Sprint?
+The Product Owner proposes how the product could increase its value and utility in the current Sprint. The whole Scrum Team then collaborates to define a Sprint Goal that communicates why the Sprint is valuable to stakeholders. The Sprint Goal must be finalized prior to the end of Sprint Planning.
 
-The Development Team works to forecast the functionality that will be developed during the Sprint. The Product Owner discusses the objective that the Sprint should achieve and the Product Backlog items that, if completed in the Sprint, would achieve the Sprint Goal. The entire Scrum Team collaborates on understanding the work of the Sprint.
+#### Topic Two: What can be Done this Sprint?
 
-The input to this meeting is the Product Backlog, the latest product Increment, projected capacity of the Development Team during the Sprint, and past performance of the Development Team. The number of items selected from the Product Backlog for the Sprint is solely up to the Development Team. Only the Development Team can assess what it can accomplish over the upcoming Sprint.
+Through discussion with the Product Owner, the Developers select items from the Product Backlog to include in the current Sprint. The Scrum Team may refine these items during this process, which increases understanding and confidence.
 
-During Sprint Planning the Scrum Team also crafts a Sprint Goal. The Sprint Goal is an objective that will be met within the Sprint through the implementation of the Product Backlog, and it provides guidance to the Development Team on why it is building the Increment.
+Selecting how much can be completed within a Sprint may be challenging. However, the more the Developers know about their past performance, their upcoming capacity, and their Definition of Done, the more confident they will be in their Sprint forecasts.
 
-#### Topic Two: how will the chosen work get done?
+#### Topic Three: How will the chosen work get done?
 
-Having set the Sprint Goal and selected the Product Backlog items for the Sprint, the Development Team decides how it will build this functionality into a "Done" product Increment during the Sprint. The Product Backlog items selected for this Sprint plus the plan for delivering them is called the Sprint Backlog.
+For each selected Product Backlog item, the Developers plan the work necessary to create an Increment that meets the Definition of Done. This is often done by decomposing Product Backlog items into smaller work items of one day or less. How this is done is at the sole discretion of the Developers. No one else tells them how to turn Product Backlog items into Increments of value.
 
-The Development Team usually starts by designing the system and the work needed to convert the Product Backlog into a working product Increment. Work may be of varying size, or estimated effort. However, enough work is planned during Sprint Planning for the Development Team to forecast what it believes it can do in the upcoming Sprint. Work planned for the first days of the Sprint by the Development Team is decomposed by the end of this meeting, often to units of one day or less. The Development Team self-organizes to undertake the work in the Sprint Backlog, both during Sprint Planning and as needed throughout the Sprint.
+The Sprint Goal, the Product Backlog items selected for the Sprint, plus the plan for delivering them are together referred to as the Sprint Backlog.
 
-The Product Owner can help to clarify the selected Product Backlog items and make trade-offs. If the Development Team determines it has too much or too little work, it may renegotiate the selected Product Backlog items with the Product Owner. The Development Team may also invite other people to attend to provide technical or domain advice.
-
-By the end of the Sprint Planning, the Development Team should be able to explain to the Product Owner and Scrum Master how it intends to work as a self-organizing team to accomplish the Sprint Goal and create the anticipated Increment.
-
-#### Sprint Goal
-
-The Sprint Goal is an objective set for the Sprint that can be met through the implementation of Product Backlog. It provides guidance to the Development Team on why it is building the Increment. It is created during the Sprint Planning meeting. The Sprint Goal gives the Development Team some flexibility regarding the functionality implemented within the Sprint. The selected Product Backlog items deliver one coherent function, which can be the Sprint Goal. The Sprint Goal can be any other coherence that causes the Development Team to work together rather than on separate initiatives.
-
-As the Development Team works, it keeps the Sprint Goal in mind. In order to satisfy the Sprint Goal, it implements functionality and technology. If the work turns out to be different than the Development Team expected, they collaborate with the Product Owner to negotiate the scope of Sprint Backlog within the Sprint.
+Sprint Planning is timeboxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
 
 ### Daily Scrum
 
-The Daily Scrum is a 15-minute time-boxed event for the Development Team. The Daily Scrum is held every day of the Sprint. At it, the Development Team plans work for the next 24 hours. This optimizes team collaboration and performance by inspecting the work since the last Daily Scrum and forecasting upcoming Sprint work. The Daily Scrum is held at the same time and place each day to reduce complexity.
+The purpose of the Daily Scrum is to inspect progress toward the Sprint Goal and adapt the Sprint Backlog as necessary, adjusting the upcoming planned work.
 
-The Development Team uses the Daily Scrum to inspect progress toward the Sprint Goal and to inspect how progress is trending toward completing the work in the Sprint Backlog. The Daily Scrum optimizes the probability that the Development Team will meet the Sprint Goal. Every day, the Development Team should understand how it intends to work together as a self-organizing team to accomplish the Sprint Goal and create the anticipated Increment by the end of the Sprint.
+The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is held at the same time and place every working day of the Sprint. If the Product Owner or Scrum Master are actively working on items in the Sprint Backlog, they participate as Developers.
 
-The structure of the meeting is set by the Development Team and can be conducted in different ways if it focuses on progress toward the Sprint Goal. Some Development Teams will use questions, some will be more discussion based. Here is an example of what might be used:
+The Developers can select whatever structure and techniques they want, as long as their Daily Scrum focuses on progress toward the Sprint Goal and produces an actionable plan for the next day of work. This creates focus and improves self-management.
 
-- What did I do yesterday that helped the Development Team meet the Sprint Goal?
-- What will I do today to help the Development Team meet the Sprint Goal?
-- Do I see any impediment that prevents me or the Development Team from meeting the Sprint Goal?
+Daily Scrums improve communications, identify impediments, promote quick decision-making, and consequently eliminate the need for other meetings.
 
-The Development Team or team members often meet immediately after the Daily Scrum for detailed discussions, or to adapt, or replan, the rest of the Sprint’s work.
-
-The Scrum Master ensures that the Development Team has the meeting, but the Development Team is responsible for conducting the Daily Scrum. The Scrum Master teaches the Development Team to keep the Daily Scrum within the 15-minute time-box.
-
-The Daily Scrum is an internal meeting for the Development Team. If others are present, the Scrum Master ensures that they do not disrupt the meeting.
-
-Daily Scrums improve communications, eliminate other meetings, identify impediments to development for removal, highlight and promote quick decision-making, and improve the Development Team’s level of knowledge. This is a key inspect and adapt meeting.
+The Daily Scrum is not the only time Developers are allowed to adjust their plan. They often meet throughout the day for more detailed discussions about adapting or re-planning the rest of the Sprint’s work.
 
 ### Sprint Review
 
-A Sprint Review is held at the end of the Sprint to inspect the Increment and adapt the Product Backlog if needed. During the Sprint Review, the Scrum Team and stakeholders collaborate about what was done in the Sprint. Based on that and any changes to the Product Backlog during the Sprint, attendees collaborate on the next things that could be done to optimize value. This is an informal meeting, not a status meeting, and the presentation of the Increment is intended to elicit feedback and foster collaboration.
+The purpose of the Sprint Review is to inspect the outcome of the Sprint and determine future adaptations. The Scrum Team presents the results of their work to key stakeholders and progress toward the Product Goal is discussed.
 
-This is at most a four-hour meeting for one-month Sprints. For shorter Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and that attendees understand its purpose. The Scrum Master teaches everyone involved to keep it within the time-box.
+During the event, the Scrum Team and stakeholders review what was accomplished in the Sprint and what has changed in their environment. Based on this information, attendees collaborate on what to do next. The Product Backlog may also be adjusted to meet new opportunities. The Sprint Review is a working session and the Scrum Team should avoid limiting it to a presentation.
 
-The Sprint Review includes the following elements:
-
-- Attendees include the Scrum Team and key stakeholders invited by the Product Owner;
-- The Product Owner explains what Product Backlog items have been "Done" and what has not been "Done";
-- The Development Team discusses what went well during the Sprint, what problems it ran into, and how those problems were solved;
-- The Development Team demonstrates the work that it has "Done" and answers questions about the Increment;
-- The Product Owner discusses the Product Backlog as it stands. He or she projects likely target and delivery dates based on progress to date (if needed);
-- The entire group collaborates on what to do next, so that the Sprint Review provides valuable input to subsequent Sprint Planning;
-- Review of how the marketplace or potential use of the product might have changed what is the most valuable thing to do next; and,
-- Review of the timeline, budget, potential capabilities, and marketplace for the next anticipated releases of functionality or capability of the product.
-
-The result of the Sprint Review is a revised Product Backlog that defines the probable Product Backlog items for the next Sprint. The Product Backlog may also be adjusted overall to meet new opportunities.
+The Sprint Review is the second to last event of the Sprint and is timeboxed to a maximum of four hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
 
 ### Sprint Retrospective
 
-The Sprint Retrospective is an opportunity for the Scrum Team to inspect itself and create a plan for improvements to be enacted during the next Sprint.
+The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness.
 
-The Sprint Retrospective occurs after the Sprint Review and prior to the next Sprint Planning. This is at most a three-hour meeting for one-month Sprints. For shorter Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and that attendants understand its purpose.
+The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes, tools, and their Definition of Done. Inspected elements often vary with the domain of work. Assumptions that led them astray are identified and their origins explored. The Scrum Team discusses what went well during the Sprint, what problems it encountered, and how those problems were (or were not) solved.
 
-The Scrum Master ensures that the meeting is positive and productive. The Scrum Master teaches all to keep it within the time-box. The Scrum Master participates as a peer team member in the meeting from the accountability over the Scrum process.
+The Scrum Team identifies the most helpful changes to improve its effectiveness. The most impactful improvements are addressed as soon as possible. They may even be added to the Sprint Backlog for the next Sprint.
 
-The purpose of the Sprint Retrospective is to:
+The Sprint Retrospective concludes the Sprint. It is timeboxed to a maximum of three hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
 
-- Inspect how the last Sprint went with regards to people, relationships, process, and tools;
-- Identify and order the major items that went well and potential improvements; and,
-- Create a plan for implementing improvements to the way the Scrum Team does its work.
+## Scrum Artifacts
 
-The Scrum Master encourages the Scrum Team to improve, within the Scrum process framework, its development process and practices to make it more effective and enjoyable for the next Sprint. During each Sprint Retrospective, the Scrum Team plans ways to increase product quality by improving work processes or adapting the definition of "Done", if appropriate and not in conflict with product or organizational standards.
+Scrum’s artifacts represent work or value. They are designed to maximize transparency of key information. Thus, everyone inspecting them has the same basis for adaptation.
 
-By the end of the Sprint Retrospective, the Scrum Team should have identified improvements that it will implement in the next Sprint. Implementing these improvements in the next Sprint is the adaptation to the inspection of the Scrum Team itself. Although improvements may be implemented at any time, the Sprint Retrospective provides a formal opportunity to focus on inspection and adaptation.
+Each artifact contains a commitment to ensure it provides information that enhances transparency and focus against which progress can be measured:
 
-##Scrum Artifacts
+For the Product Backlog it is the Product Goal.
 
-Scrum’s artifacts represent work or value to provide transparency and opportunities for inspection and adaptation. Artifacts defined by Scrum are specifically designed to maximize transparency of key information so that everybody has the same understanding of the artifact.
+For the Sprint Backlog it is the Sprint Goal.
+
+For the Increment it is the Definition of Done.
+
+These commitments exist to reinforce empiricism and the Scrum values for the Scrum Team and their stakeholders.
 
 ### Product Backlog
 
-The Product Backlog is an ordered list of everything that is known to be needed in the product. It is the single source of requirements for any changes to be made to the product. The Product Owner is responsible for the Product Backlog, including its content, availability, and ordering.
+The Product Backlog is an emergent, ordered list of what is needed to improve the product. It is the single source of work undertaken by the Scrum Team.
 
-A Product Backlog is never complete. The earliest development of it lays out the initially known and best-understood requirements. The Product Backlog evolves as the product and the environment in which it will be used evolves. The Product Backlog is dynamic; it constantly changes to identify what the product needs to be appropriate, competitive, and useful. If a product exists, its Product Backlog also exists.
+Product Backlog items that can be Done by the Scrum Team within one Sprint are deemed ready for selection in a Sprint Planning event. They usually acquire this degree of transparency after refining activities. Product Backlog refinement is the act of breaking down and further defining Product Backlog items into smaller more precise items. This is an ongoing activity to add details, such as a description, order, and size. Attributes often vary with the domain of work.
 
-The Product Backlog lists all features, functions, requirements, enhancements, and fixes that constitute the changes to be made to the product in future releases. Product Backlog items have the attributes of a description, order, estimate, and value. Product Backlog items often include test descriptions that will prove its completeness when "Done".
+The Developers who will be doing the work are responsible for the sizing. The Product Owner may influence the Developers by helping them understand and select trade-offs.
 
-As a product is used and gains value, and the marketplace provides feedback, the Product Backlog becomes a larger and more exhaustive list. Requirements never stop changing, so a Product Backlog is a living artifact. Changes in business requirements, market conditions, or technology may cause changes in the Product Backlog.
+#### Commitment: Product Goal
 
-Multiple Scrum Teams often work together on the same product. One Product Backlog is used to describe the upcoming work on the product. A Product Backlog attribute that groups items may then be employed.
+The Product Goal describes a future state of the product which can serve as a target for the Scrum Team to plan against. The Product Goal is in the Product Backlog. The rest of the Product Backlog emerges to define “what” will fulfill the Product Goal.
 
-Product Backlog refinement is the act of adding detail, estimates, and order to items in the Product Backlog. This is an ongoing process in which the Product Owner and the Development Team collaborate on the details of Product Backlog items. During Product Backlog refinement, items are reviewed and revised. The Scrum Team decides how and when refinement is done. Refinement usually consumes no more than 10% of the capacity of the Development Team. However, Product Backlog items can be updated at any time by the Product Owner or at the Product Owner’s discretion.
+> A product is a vehicle to deliver value. It has a clear boundary, known stakeholders, well-defined users or customers. A product could be a service, a physical product, or something more abstract.
 
-Higher ordered Product Backlog items are usually clearer and more detailed than lower ordered ones. More precise estimates are made based on the greater clarity and increased detail; the lower the order, the less detail. Product Backlog items that will occupy the Development Team for the upcoming Sprint are refined so that any one item can reasonably be "Done" within the Sprint time-box. Product Backlog items that can be "Done" by the Development Team within one Sprint are deemed "Ready" for selection in a Sprint Planning. Product Backlog items usually acquire this degree of transparency through the above described refining activities.
-
-The Development Team is responsible for all estimates. The Product Owner may influence the Development Team by helping it understand and select trade-offs, but the people who will perform the work make the final estimate.
-
-#### Monitoring Progress Toward Goals
-
-At any point in time, the total work remaining to reach a goal can be summed. The Product Owner tracks this total work remaining at least every Sprint Review. The Product Owner compares this amount with work remaining at previous Sprint Reviews to assess progress toward completing projected work by the desired time for the goal. This information is made transparent to all stakeholders.
-
-Various projective practices upon trending have been used to forecast progress, like burn-downs, burn-ups, or cumulative flows. These have proven useful. However, these do not replace the importance of empiricism. In complex environments, what will happen is unknown. Only what has already happened may be used for forward-looking decision-making.
+The Product Goal is the long-term objective for the Scrum Team. They must fulfill (or abandon) one objective before taking on the next.
 
 ### Sprint Backlog
 
-The Sprint Backlog is the set of Product Backlog items selected for the Sprint, plus a plan for delivering the product Increment and realizing the Sprint Goal. The Sprint Backlog is a forecast by the Development Team about what functionality will be in the next Increment and the work needed to deliver that functionality into a "Done" Increment.
+The Sprint Backlog is composed of the Sprint Goal (why), the set of Product Backlog items selected for the Sprint (what), as well as an actionable plan for delivering the Increment (how).
 
-The Sprint Backlog makes visible all the work that the Development Team identifies as necessary to meet the Sprint Goal. To ensure continuous improvement, it includes at least one high priority process improvement identified in the previous Retrospective meeting.
+The Sprint Backlog is a plan by and for the Developers. It is a highly visible, real-time picture of the work that the Developers plan to accomplish during the Sprint in order to achieve the Sprint Goal. Consequently, the Sprint Backlog is updated throughout the Sprint as more is learned. It should have enough detail that they can inspect their progress in the Daily Scrum.
 
-The Sprint Backlog is a plan with enough detail that changes in progress can be understood in the Daily Scrum. The Development Team modifies the Sprint Backlog throughout the Sprint, and the Sprint Backlog emerges during the Sprint. This emergence occurs as the Development Team works through the plan and learns more about the work needed to achieve the Sprint Goal.
+#### Commitment: Sprint Goal
 
-As new work is required, the Development Team adds it to the Sprint Backlog. As work is performed or completed, the estimated remaining work is updated. When elements of the plan are deemed unnecessary, they are removed. Only the Development Team can change its Sprint Backlog during a Sprint. The Sprint Backlog is a highly visible, real-time picture of the work that the Development Team plans to accomplish during the Sprint, and it belongs solely to the Development Team.
+The Sprint Goal is the single objective for the Sprint. Although the Sprint Goal is a commitment by the Developers, it provides flexibility in terms of the exact work needed to achieve it. The Sprint Goal also creates coherence and focus, encouraging the Scrum Team to work together rather than on separate initiatives.
 
-#### Monitoring Sprint Progress
-
-At any point in time in a Sprint, the total work remaining in the Sprint Backlog can be summed. The Development Team tracks this total work remaining at least for every Daily Scrum to project the likelihood of achieving the Sprint Goal. By tracking the remaining work throughout the Sprint, the Development Team can manage its progress.
+The Sprint Goal is created during the Sprint Planning event and then added to the Sprint Backlog. As the Developers work during the Sprint, they keep the Sprint Goal in mind. If the work turns out to be different than they expected, they collaborate with the Product Owner to negotiate the scope of the Sprint Backlog within the Sprint without affecting the Sprint Goal.
 
 ### Increment
 
-The Increment is the sum of all the Product Backlog items completed during a Sprint and the value of the increments of all previous Sprints. At the end of a Sprint, the new Increment must be "Done," which means it must be in useable condition and meet the Scrum Team’s definition of "Done". An increment is a body of inspectable, done work that supports empiricism at the end of the Sprint. The increment is a step toward a vision or goal. The increment must be in useable condition regardless of whether the Product Owner decides to release it.
+An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all prior Increments and thoroughly verified, ensuring that all Increments work together. In order to provide value, the Increment must be usable.
 
-## Artifact Transparency
+Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the Sprint Review thus supporting empiricism. However, an Increment may be delivered to stakeholders prior to the end of the Sprint. The Sprint Review should never be considered a gate to releasing value.
 
-Scrum relies on transparency. Decisions to optimize value and control risk are made based on the perceived state of the artifacts. To the extent that transparency is complete, these decisions have a sound basis. To the extent that the artifacts are incompletely transparent, these decisions can be flawed, value may diminish and risk may increase.
+Work cannot be considered part of an Increment unless it meets the Definition of Done.
 
-The Scrum Master must work with the Product Owner, Development Team, and other involved parties to understand if the artifacts are completely transparent. There are practices for coping with incomplete transparency; the Scrum Master must help everyone apply the most appropriate practices in the absence of complete transparency. A Scrum Master can detect incomplete transparency by inspecting the artifacts, sensing patterns, listening closely to what is being said, and detecting differences between expected and real results.
+#### Commitment: Definition of Done
 
-The Scrum Master’s job is to work with the Scrum Team and the organization to increase the transparency of the artifacts. This work usually involves learning, convincing, and change. Transparency doesn’t occur overnight, but is a path.
+The Definition of Done is a formal description of the state of the Increment when it meets the quality measures required for the product.
 
-### Definition of "Done"
+The moment a Product Backlog item meets the Definition of Done, an Increment is born.
 
-When a Product Backlog item or an Increment is described as "Done", everyone must understand what "Done" means. Although this may vary significantly per Scrum Team, members must have a shared understanding of what it means for work to be complete, to ensure transparency. This is the definition of "Done" for the Scrum Team and is used to assess when work is complete on the product Increment.
+The Definition of Done creates transparency by providing everyone a shared understanding of what work was completed as part of the Increment. If a Product Backlog item does not meet the Definition of Done, it cannot be released or even presented at the Sprint Review. Instead, it returns to the Product Backlog for future consideration.
 
-The same definition guides the Development Team in knowing how many Product Backlog items it can select during a Sprint Planning. The purpose of each Sprint is to deliver Increments of potentially releasable functionality that adhere to the Scrum Team’s current definition of "Done".
+If the Definition of Done for an increment is part of the standards of the organization, all Scrum Teams must follow it as a minimum. If it is not an organizational standard, the Scrum Team must create a Definition of Done appropriate for the product.
 
-Development Teams deliver an Increment of product functionality every Sprint. This Increment is useable, so a Product Owner may choose to immediately release it. If the definition of "Done" for an increment is part of the conventions, standards or guidelines of the development organization, all Scrum Teams must follow it as a minimum.
-
-If "Done" for an increment is not a convention of the development organization, the Development Team of the Scrum Team must define a definition of "Done" appropriate for the product. If there are multiple Scrum Teams working on the system or product release, the Development Teams on all the Scrum Teams must mutually define the definition of "Done".
-
-Each Increment is additive to all prior Increments and thoroughly tested, ensuring that all Increments work together.
-
-As Scrum Teams mature, it is expected that their definitions of "Done" will expand to include more stringent criteria for higher quality. New definitions, as used, may uncover work to be done in previously "Done" increments. Any one product or system should have a definition of "Done" that is a standard for any work done on it.
+The Developers are required to conform to the Definition of Done. If there are multiple Scrum Teams working together on a product, they must mutually define and comply with the same Definition of Done.
 
 ## End Note
 
-Scrum is free and offered in this Guide. Scrum’s roles, events, artifacts, and rules are immutable and although implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists only in its entirety and functions well as a container for other techniques, methodologies, and practices.
+Scrum is free and offered in this Guide. The Scrum framework, as outlined herein, is immutable. While implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists only in its entirety and functions well as a container for other techniques, methodologies, and practices.
 
-## Acknowledgements
+### Acknowledgements
 
-### People
+#### People
 
 Of the thousands of people who have contributed to Scrum, we should single out those who were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them worked together. Many others contributed in the ensuing years and without their help Scrum would not be refined as it is today.
 
-### History
+#### Scrum Guide History
 
-Ken Schwaber and Jeff Sutherland worked on Scrum until 1995, when they co-presented Scrum at the OOPSLA Conference in 1995. This presentation essentially documented the learning that Ken and Jeff gained over the previous few years, and made public the first formal definition of Scrum.
+Ken Schwaber and Jeff Sutherland first co-presented Scrum at the OOPSLA Conference in 1995. It essentially documented the learning that Ken and Jeff gained over the previous few years and made public the first formal definition of Scrum.
 
-The history of Scrum is described elsewhere. To honor the first places where it was tried and refined, we recognize Individual, Inc., Newspage, Fidelity Investments, and IDX (now GE Health).
+The Scrum Guide documents Scrum as developed, evolved, and sustained for 30-plus years by Jeff Sutherland and Ken Schwaber. Other sources provide patterns, processes, and insights that complement the Scrum framework. These may increase productivity, value, creativity, and satisfaction with the results.
 
-The Scrum Guide documents Scrum as developed, evolved, and sustained for 20-plus years by Jeff Sutherland and Ken Schwaber. Other sources provide you with patterns, processes, and insights that complement the Scrum framework. These may increase productivity, value, creativity, and satisfaction with the results.
+The complete history of Scrum is described elsewhere. To honor the first places where it was tried and proven, we recognize Individual Inc., Newspage, Fidelity Investments, and IDX (now GE Medical).
 
-©2018 Ken Schwaber and Jeff Sutherland. Offered for license under the Attribution Share-Alike license of Creative Commons, accessible at http://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary form at http://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide you acknowledge and agree that you have read and agree to be bound by the terms of the Attribution ShareAlike license of Creative Commons.
+© 2020 Ken Schwaber and Jeff Sutherland This publication is offered for license under the Attribution Share-Alike license of Creative Commons, accessible at https://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary form at https://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide, you acknowledge and agree that you have read and agree to be bound by the terms of the Attribution Share-Alike license of Creative Commons.

--- a/scrum guide
+++ b/scrum guide
@@ -1,4 +1,5 @@
-﻿The Scrum Guide
+﻿# The Scrum Guide
+
 The Definitive Guide to Scrum:
 The Rules of the Game
 
@@ -6,531 +7,367 @@ November 2017
 
 Developed and sustained by Scrum creators: Ken Schwaber and Jeff Sutherland
 
-Purpose of the Scrum Guide
-Scrum is a framework for developing, delivering, and sustaining complex products. This Guide contains the
-definition of Scrum. This definition consists of Scrum’s roles, events, artifacts, and the rules that 
-bind them together. Ken Schwaber and Jeff Sutherland developed Scrum; the Scrum Guide is 
-written and provided by them. Together, they stand behind the Scrum Guide.
-Definition of Scrum
-Scrum (n): A framework within which people can address complex adaptive problems, while
-productively and creatively delivering products of the highest possible value.
+## Purpose of the Scrum Guide
+
+Scrum is a framework for developing, delivering, and sustaining complex products. This Guide contains the definition of Scrum. This definition consists of Scrum’s roles, events, artifacts, and the rules that bind them together. Ken Schwaber and Jeff Sutherland developed Scrum; the Scrum Guide is written and provided by them. Together, they stand behind the Scrum Guide.
+
+## Definition of Scrum
+
+Scrum (n): A framework within which people can address complex adaptive problems, while productively and creatively delivering products of the highest possible value.
+
 Scrum is:
+
 - Lightweight
 - Simple to understand
 - Difficult to master
-Scrum is a process framework that has been used to manage work on complex products 
-since the early 1990s. Scrum is not a process, technique, or definitive method. Rather, it is a
-framework within which you can employ various processes and techniques. Scrum makes clear
-the relative efficacy of your product management and work techniques so that you can
-continuously improve the product, the team, and the working environment.
-The Scrum framework consists of Scrum Teams and their associated roles, events, artifacts, and
-rules. Each component within the framework serves a specific purpose and is essential to
-Scrum’s success and usage.
-The rules of Scrum bind together the roles, events, and artifacts, governing the relationships and
-interaction between them. The rules of Scrum are described throughout the body of this
-document.
+
+Scrum is a process framework that has been used to manage work on complex products since the early 1990s. Scrum is not a process, technique, or definitive method. Rather, it is a framework within which you can employ various processes and techniques. Scrum makes clear the relative efficacy of your product management and work techniques so that you can continuously improve the product, the team, and the working environment.
+
+The Scrum framework consists of Scrum Teams and their associated roles, events, artifacts, and rules. Each component within the framework serves a specific purpose and is essential to Scrum’s success and usage.
+
+The rules of Scrum bind together the roles, events, and artifacts, governing the relationships and interaction between them. The rules of Scrum are described throughout the body of this document.
+
 Specific tactics for using the Scrum framework vary and are described elsewhere.
 
-Uses of Scrum
-Scrum was initially developed for managing and developing products. Starting in the early
-1990s, Scrum has been used extensively, worldwide, to:
+## Uses of Scrum
+
+Scrum was initially developed for managing and developing products. Starting in the early 1990s, Scrum has been used extensively, worldwide, to:
+
 1. Research and identify viable markets, technologies, and product capabilities;
 2. Develop products and enhancements;
 3. Release products and enhancements, as frequently as many times per day;
-4. Develop and sustain Cloud (online, secure, on-demand) and other operational
-environments for product use; and,
+4. Develop and sustain Cloud (online, secure, on-demand) and other operational environments for product use; and,
 5. Sustain and renew products.
-Scrum has been used to develop software, hardware, embedded software, networks of
-interacting function, autonomous vehicles, schools, government, marketing, managing the
-operation of organizations and almost everything we use in our daily lives, as individuals and
-societies.
-As technology, market, and environmental complexities and their interactions have rapidly
-increased, Scrum’s utility in dealing with complexity is proven daily.
-Scrum proved especially effective in iterative and incremental knowledge transfer. Scrum is now
-widely used for products, services, and the management of the parent organization.
-The essence of Scrum is a small team of people. The individual team is highly flexible and
-adaptive. These strengths continue operating in single, several, many, and networks of teams
-that develop, release, operate and sustain the work and work products of thousands of people.
-They collaborate and interoperate through sophisticated development architectures and target
-release environments.
-When the words “develop” and “development” are used in the Scrum Guide, they refer to
-complex work, such as those types identified above.
 
+Scrum has been used to develop software, hardware, embedded software, networks of interacting function, autonomous vehicles, schools, government, marketing, managing the operation of organizations and almost everything we use in our daily lives, as individuals and societies.
 
-Scrum Theory
-Scrum is founded on empirical process control theory, or empiricism. Empiricism asserts that
-knowledge comes from experience and making decisions based on what is known. Scrum
-employs an iterative, incremental approach to optimize predictability and control risk.
-Three pillars uphold every implementation of empirical process control: transparency,
-inspection, and adaptation.
+As technology, market, and environmental complexities and their interactions have rapidly increased, Scrum’s utility in dealing with complexity is proven daily.
 
-Transparency
-Significant aspects of the process must be visible to those responsible for the outcome.
-Transparency requires those aspects be defined by a common standard so observers share a
-common understanding of what is being seen.
-For example
-- A common language referring to the process must be shared by all participants; and,
-- Those performing the work and those inspecting the resulting increment must share a
-common definition of “Done”.
+Scrum proved especially effective in iterative and incremental knowledge transfer. Scrum is now widely used for products, services, and the management of the parent organization.
+
+The essence of Scrum is a small team of people. The individual team is highly flexible and adaptive. These strengths continue operating in single, several, many, and networks of teams that develop, release, operate and sustain the work and work products of thousands of people. They collaborate and interoperate through sophisticated development architectures and target release environments.
+
+When the words "develop" and "development" are used in the Scrum Guide, they refer to complex work, such as those types identified above.
+
+## Scrum Theory
+
+Scrum is founded on empirical process control theory, or empiricism. Empiricism asserts that knowledge comes from experience and making decisions based on what is known. Scrum employs an iterative, incremental approach to optimize predictability and control risk. Three pillars uphold every implementation of empirical process control: transparency, inspection, and adaptation.
+
+### Transparency
+
+Significant aspects of the process must be visible to those responsible for the outcome. Transparency requires those aspects be defined by a common standard so observers share a common understanding of what is being seen.
+
+For example:
+
+A common language referring to the process must be shared by all participants; and,
+Those performing the work and those inspecting the resulting increment must share a common definition of "Done".
 Inspection
-Scrum users must frequently inspect Scrum artifacts and progress toward a Sprint Goal to detect
-undesirable variances. Their inspection should not be so frequent that inspection gets in the way
-of the work. Inspections are most beneficial when diligently performed by skilled inspectors at
-the point of work.
-Adaptation
-If an inspector determines that one or more aspects of a process deviate outside acceptable
-limits, and that the resulting product will be unacceptable, the process or the material being
-processed must be adjusted. An adjustment must be made as soon as possible to minimize
-further deviation.
-Scrum prescribes four formal events for inspection and adaptation, as described in the Scrum
-Events section of this document:
+Scrum users must frequently inspect Scrum artifacts and progress toward a Sprint Goal to detect undesirable variances. Their inspection should not be so frequent that inspection gets in the way of the work. Inspections are most beneficial when diligently performed by skilled inspectors at the point of work.
+
+### Adaptation
+
+If an inspector determines that one or more aspects of a process deviate outside acceptable limits, and that the resulting product will be unacceptable, the process or the material being processed must be adjusted. An adjustment must be made as soon as possible to minimize further deviation.
+
+Scrum prescribes four formal events for inspection and adaptation, as described in the Scrum Events section of this document:
+
 - Sprint Planning
 - Daily Scrum
 - Sprint Review
 - Sprint Retrospective
-Scrum Values
-When the values of commitment, courage, focus, openness and respect are embodied and lived
-by the Scrum Team, the Scrum pillars of transparency, inspection, and adaptation come to life
-and build trust for everyone. The Scrum Team members learn and explore those values as they
-work with the Scrum roles, events, and artifacts.
-Successful use of Scrum depends on people becoming more proficient in living these five values.
-People personally commit to achieving the goals of the Scrum Team. The Scrum Team members
-have courage to do the right thing and work on tough problems. Everyone focuses on the work
-of the Sprint and the goals of the Scrum Team. The Scrum Team and its stakeholders agree to be
-open about all the work and the challenges with performing the work. Scrum Team members
-respect each other to be capable, independent people.
 
+## Scrum Values
 
-The Scrum Team
-The Scrum Team consists of a Product Owner, the Development Team, and a Scrum Master.
-Scrum Teams are self-organizing and cross-functional. Self-organizing teams choose how best to
-accomplish their work, rather than being directed by others outside the team. Cross-functional
-teams have all competencies needed to accomplish the work without depending on others not
-part of the team. The team model in Scrum is designed to optimize flexibility, creativity, and
-productivity. The Scrum Team has proven itself to be increasingly effective for all the earlier
-stated uses, and any complex work.
-Scrum Teams deliver products iteratively and incrementally, maximizing opportunities for
-feedback. Incremental deliveries of “Done” product ensure a potentially useful version of
-working product is always available.
-The Product Owner
-The Product Owner is responsible for maximizing the value of the product resulting from work
-of the Development Team. How this is done may vary widely across organizations, Scrum Teams,
-and individuals.
-The Product Owner is the sole person responsible for managing the Product Backlog. Product
-Backlog management includes:
+When the values of commitment, courage, focus, openness and respect are embodied and lived by the Scrum Team, the Scrum pillars of transparency, inspection, and adaptation come to life and build trust for everyone. The Scrum Team members learn and explore those values as they work with the Scrum events, roles and artifacts.
+
+Successful use of Scrum depends on people becoming more proficient in living these five values. People personally commit to achieving the goals of the Scrum Team. The Scrum Team members have courage to do the right thing and work on tough problems. Everyone focuses on the work of the Sprint and the goals of the Scrum Team. The Scrum Team and its stakeholders agree to be open about all the work and the challenges with performing the work. Scrum Team members respect each other to be capable, independent people.
+
+## The Scrum Team
+
+The Scrum Team consists of a Product Owner, the Development Team, and a Scrum Master. Scrum Teams are self-organizing and cross-functional. Self-organizing teams choose how best to accomplish their work, rather than being directed by others outside the team. Cross-functional teams have all competencies needed to accomplish the work without depending on others not part of the team. The team model in Scrum is designed to optimize flexibility, creativity, and productivity. The Scrum Team has proven itself to be increasingly effective for all the earlier stated uses, and any complex work.
+
+Scrum Teams deliver products iteratively and incrementally, maximizing opportunities for feedback. Incremental deliveries of "Done" product ensure a potentially useful version of working product is always available.
+
+### The Product Owner
+
+The Product Owner is responsible for maximizing the value of the product resulting from work of the Development Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.
+
+The Product Owner is the sole person responsible for managing the Product Backlog. Product Backlog management includes:
+
 - Clearly expressing Product Backlog items;
 - Ordering the items in the Product Backlog to best achieve goals and missions;
 - Optimizing the value of the work the Development Team performs;
-- Ensuring that the Product Backlog is visible, transparent, and clear to all, and shows what
-the Scrum Team will work on next; and,
-- Ensuring the Development Team understands items in the Product Backlog to the level
-needed.
-The Product Owner may do the above work, or have the Development Team do it. However, the
-Product Owner remains accountable.
-The Product Owner is one person, not a committee. The Product Owner may represent the
-desires of a committee in the Product Backlog, but those wanting to change a Product Backlog
-item’s priority must address the Product Owner.
-For the Product Owner to succeed, the entire organization must respect his or her decisions. The
-Product Owner’s decisions are visible in the content and ordering of the Product Backlog. No
-one can force the Development Team to work from a different set of requirements.
+- Ensuring that the Product Backlog is visible, transparent, and clear to all, and shows what the Scrum Team will work on next; and,
+- Ensuring the Development Team understands items in the Product Backlog to the level needed.
 
+The Product Owner may do the above work, or have the Development Team do it. However, the Product Owner remains accountable.
 
-The Development Team
-The Development Team consists of professionals who do the work of delivering a potentially
-releasable Increment of “Done” product at the end of each Sprint. A “Done” increment is
-required at the Sprint Review. Only members of the Development Team create the Increment.
-Development Teams are structured and empowered by the organization to organize and
-manage their own work. The resulting synergy optimizes the Development Team’s overall
-efficiency and effectiveness.
+The Product Owner is one person, not a committee. The Product Owner may represent the desires of a committee in the Product Backlog, but those wanting to change a Product Backlog item’s priority must address the Product Owner.
+
+For the Product Owner to succeed, the entire organization must respect his or her decisions. The Product Owner’s decisions are visible in the content and ordering of the Product Backlog. No one can force the Development Team to work from a different set of requirements.
+
+### The Development Team
+
+The Development Team consists of professionals who do the work of delivering a potentially releasable Increment of "Done" product at the end of each Sprint. A "Done" increment is required at the Sprint Review. Only members of the Development Team create the Increment.
+
+Development Teams are structured and empowered by the organization to organize and manage their own work. The resulting synergy optimizes the Development Team’s overall efficiency and effectiveness.
+
 Development Teams have the following characteristics:
-- They are self-organizing. No one (not even the Scrum Master) tells the Development Team
-how to turn Product Backlog into Increments of potentially releasable functionality;
-- Development Teams are cross-functional, with all the skills as a team necessary to create
-a product Increment;
-- Scrum recognizes no titles for Development Team members, regardless of the work being
-performed by the person;
-- Scrum recognizes no sub-teams in the Development Team, regardless of domains that need
-to be addressed like testing, architecture, operations, or business analysis; and,
-- Individual Development Team members may have specialized skills and areas of focus, but
-accountability belongs to the Development Team as a whole.
-Development Team Size
-Optimal Development Team size is small enough to remain nimble and large enough to
-complete significant work within a Sprint. Fewer than three Development Team members
-decrease interaction and results in smaller productivity gains. Smaller Development Teams may
-encounter skill constraints during the Sprint, causing the Development Team to be unable to
-deliver a potentially releasable Increment. Having more than nine members requires too much
-coordination. Large Development Teams generate too much complexity for an empirical process
-to be useful. The Product Owner and Scrum Master roles are not included in this count unless
-they are also executing the work of the Sprint Backlog.
-The Scrum Master
-The Scrum Master is responsible for promoting and supporting Scrum as defined in the Scrum
-Guide. Scrum Masters do this by helping everyone understand Scrum theory, practices, rules,
-and values.
-The Scrum Master is a servant-leader for the Scrum Team. The Scrum Master helps those
-outside the Scrum Team understand which of their interactions with the Scrum Team are helpful
-and which aren’t. The Scrum Master helps everyone change these interactions to maximize the
-value created by the Scrum Team.
 
-Scrum Master Service to the Product Owner
+- They are self-organizing. No one (not even the Scrum Master) tells the Development Team how to turn Product Backlog into Increments of potentially releasable functionality;
+- Development Teams are cross-functional, with all the skills as a team necessary to create a product Increment;
+- Scrum recognizes no titles for Development Team members, regardless of the work being performed by the person;
+- Scrum recognizes no sub-teams in the Development Team, regardless of domains that need to be addressed like testing, architecture, operations, or business analysis; and,
+- Individual Development Team members may have specialized skills and areas of focus, but accountability belongs to the Development Team as a whole.
+
+#### Development Team Size
+
+Optimal Development Team size is small enough to remain nimble and large enough to complete significant work within a Sprint. Fewer than three Development Team members decrease interaction and results in smaller productivity gains. Smaller Development Teams may encounter skill constraints during the Sprint, causing the Development Team to be unable to deliver a potentially releasable Increment. Having more than nine members requires too much coordination. Large Development Teams generate too much complexity for an empirical process to be useful. The Product Owner and Scrum Master roles are not included in this count unless they are also executing the work of the Sprint Backlog.
+
+### The Scrum Master
+
+The Scrum Master is responsible for promoting and supporting Scrum as defined in the Scrum Guide. Scrum Masters do this by helping everyone understand Scrum theory, practices, rules, and values.
+
+The Scrum Master is a servant-leader for the Scrum Team. The Scrum Master helps those outside the Scrum Team understand which of their interactions with the Scrum Team are helpful and which aren’t. The Scrum Master helps everyone change these interactions to maximize the value created by the Scrum Team.
+
+#### Scrum Master Service to the Product Owner
+
 The Scrum Master serves the Product Owner in several ways, including:
-- Ensuring that goals, scope, and product domain are understood by everyone on the Scrum
-Team as well as possible;
+
+- Ensuring that goals, scope, and product domain are understood by everyone on the Scrum Team as well as possible;
 - Finding techniques for effective Product Backlog management;
 - Helping the Scrum Team understand the need for clear and concise Product Backlog items;
 - Understanding product planning in an empirical environment;
 - Ensuring the Product Owner knows how to arrange the Product Backlog to maximize value;
 - Understanding and practicing agility; and,
 - Facilitating Scrum events as requested or needed.
-Scrum Master Service to the Development Team
+
+#### Scrum Master Service to the Development Team
+
 The Scrum Master serves the Development Team in several ways, including:
+
 - Coaching the Development Team in self-organization and cross-functionality;
 - Helping the Development Team to create high-value products;
 - Removing impediments to the Development Team’s progress;
 - Facilitating Scrum events as requested or needed; and,
-- Coaching the Development Team in organizational environments in which Scrum is not yet
-fully adopted and understood.
-Scrum Master Service to the Organization
+- Coaching the Development Team in organizational environments in which Scrum is not yet fully adopted and understood.
+
+#### Scrum Master Service to the Organization
+
 The Scrum Master serves the organization in several ways, including:
+
 - Leading and coaching the organization in its Scrum adoption;
 - Planning Scrum implementations within the organization;
-- Helping employees and stakeholders understand and enact Scrum and empirical product
-development;
+- Helping employees and stakeholders understand and enact Scrum and empirical product development;
 - Causing change that increases the productivity of the Scrum Team; and,
-- Working with other Scrum Masters to increase the effectiveness of the application of Scrum
-in the organization.
-Scrum Events
-Prescribed events are used in Scrum to create regularity and to minimize the need for meetings
-not defined in Scrum. All events are time-boxed events, such that every event has a maximum
-duration. Once a Sprint begins, its duration is fixed and cannot be shortened or lengthened. The
-remaining events may end whenever the purpose of the event is achieved, ensuring an
-appropriate amount of time is spent without allowing waste in the process.
-Other than the Sprint itself, which is a container for all other events, each event in Scrum is a
-formal opportunity to inspect and adapt something. These events are specifically designed to
-enable critical transparency and inspection. Failure to include any of these events results in
-reduced transparency and is a lost opportunity to inspect and adapt.
-The Sprint
-The heart of Scrum is a Sprint, a time-box of one month or less during which a “Done”, useable,
-and potentially releasable product Increment is created. Sprints have consistent durations
-throughout a development effort. A new Sprint starts immediately after the conclusion of the
-previous Sprint.
-Sprints contain and consist of the Sprint Planning, Daily Scrums, the development work, the
-Sprint Review, and the Sprint Retrospective.
+- Working with other Scrum Masters to increase the effectiveness of the application of Scrum in the organization.
+
+## Scrum Events
+
+Prescribed events are used in Scrum to create regularity and to minimize the need for meetings not defined in Scrum. All events are time-boxed events, such that every event has a maximum duration. Once a Sprint begins, its duration is fixed and cannot be shortened or lengthened. The remaining events may end whenever the purpose of the event is achieved, ensuring an appropriate amount of time is spent without allowing waste in the process.
+
+Other than the Sprint itself, which is a container for all other events, each event in Scrum is a formal opportunity to inspect and adapt something. These events are specifically designed to enable critical transparency and inspection. Failure to include any of these events results in reduced transparency and is a lost opportunity to inspect and adapt.
+
+### The Sprint
+The heart of Scrum is a Sprint, a time-box of one month or less during which a "Done", useable, and potentially releasable product Increment is created. Sprints have consistent durations throughout a development effort. A new Sprint starts immediately after the conclusion of the previous Sprint.
+
+Sprints contain and consist of the Sprint Planning, Daily Scrums, the development work, the Sprint Review, and the Sprint Retrospective.
+
 During the Sprint:
+
 - No changes are made that would endanger the Sprint Goal;
 - Quality goals do not decrease; and,
-- Scope may be clarified and re-negotiated between the Product Owner and Development
-Team as more is learned.
-Each Sprint may be considered a project with no more than a one-month horizon. Like projects,
-Sprints are used to accomplish something. Each Sprint has a goal of what is to be built, a design
-and flexible plan that will guide building it, the work, and the resultant product increment.
-Sprints are limited to one calendar month. When a Sprint’s horizon is too long the definition of
-what is being built may change, complexity may rise, and risk may increase. Sprints enable
-predictability by ensuring inspection and adaptation of progress toward a Sprint Goal at least
-every calendar month. Sprints also limit risk to one calendar month of cost.
-Cancelling a Sprint
-A Sprint can be cancelled before the Sprint time-box is over. Only the Product Owner has the
-authority to cancel the Sprint, although he or she may do so under influence from the
-stakeholders, the Development Team, or the Scrum Master.
-A Sprint would be cancelled if the Sprint Goal becomes obsolete. This might occur if the
-company changes direction or if market or technology conditions change. In general, a Sprint
-should be cancelled if it no longer makes sense given the circumstances. But, due to the short
-duration of Sprints, cancellation rarely makes sense.
-When a Sprint is cancelled, any completed and “Done” Product Backlog items are reviewed. If
-part of the work is potentially releasable, the Product Owner typically accepts it. All incomplete
-Product Backlog Items are re-estimated and put back on the Product Backlog. The work done on
-them depreciates quickly and must be frequently re-estimated.
-Sprint cancellations consume resources, since everyone regroups in another Sprint 
-Planning to start another Sprint. Sprint cancellations are often traumatic to the Scrum Team,
-and are very uncommon.
+- Scope may be clarified and re-negotiated between the Product Owner and Development Team as more is learned.
 
-Sprint Planning
-The work to be performed in the Sprint is planned at the Sprint Planning. This plan is created by
-the collaborative work of the entire Scrum Team.
-Sprint Planning is time-boxed to a maximum of eight hours for a one-month Sprint. For shorter
-Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and
-that attendants understand its purpose. The Scrum Master teaches the Scrum Team to keep it
-within the time-box.
+Each Sprint may be considered a project with no more than a one-month horizon. Like projects, Sprints are used to accomplish something. Each Sprint has a goal of what is to be built, a design and flexible plan that will guide building it, the work, and the resultant product increment.
+
+Sprints are limited to one calendar month. When a Sprint’s horizon is too long the definition of what is being built may change, complexity may rise, and risk may increase. Sprints enable predictability by ensuring inspection and adaptation of progress toward a Sprint Goal at least every calendar month. Sprints also limit risk to one calendar month of cost.
+
+#### Cancelling a Sprint
+
+A Sprint can be cancelled before the Sprint time-box is over. Only the Product Owner has the authority to cancel the Sprint, although he or she may do so under influence from the stakeholders, the Development Team, or the Scrum Master.
+
+A Sprint would be cancelled if the Sprint Goal becomes obsolete. This might occur if the company changes direction or if market or technology conditions change. In general, a Sprint should be cancelled if it no longer makes sense given the circumstances. But, due to the short duration of Sprints, cancellation rarely makes sense.
+
+When a Sprint is cancelled, any completed and "Done" Product Backlog items are reviewed. If part of the work is potentially releasable, the Product Owner typically accepts it. All incomplete Product Backlog Items are re-estimated and put back on the Product Backlog. The work done on them depreciates quickly and must be frequently re-estimated.
+
+Sprint cancellations consume resources, since everyone regroups in another Sprint Planning to start another Sprint. Sprint cancellations are often traumatic to the Scrum Team, and are very uncommon.
+
+### Sprint Planning
+
+The work to be performed in the Sprint is planned at the Sprint Planning. This plan is created by the collaborative work of the entire Scrum Team.
+
+Sprint Planning is time-boxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and that attendants understand its purpose. The Scrum Master teaches the Scrum Team to keep it within the time-box.
 
 Sprint Planning answers the following:
+
 - What can be delivered in the Increment resulting from the upcoming Sprint?
 - How will the work needed to deliver the Increment be achieved?
 
-Topic One: What can be done this Sprint?
-The Development Team works to forecast the functionality that will be developed during the
-Sprint. The Product Owner discusses the objective that the Sprint should achieve and the
-Product Backlog items that, if completed in the Sprint, would achieve the Sprint Goal. The entire
-Scrum Team collaborates on understanding the work of the Sprint.
-The input to this meeting is the Product Backlog, the latest product Increment, projected
-capacity of the Development Team during the Sprint, and past performance of the Development
-Team. The number of items selected from the Product Backlog for the Sprint is solely up to the
-Development Team. Only the Development Team can assess what it can accomplish over the
-upcoming Sprint.
-During Sprint Planning the Scrum Team also crafts a Sprint Goal. The Sprint Goal is an objective
-that will be met within the 
-Sprint through the implementation of the Product Backlog, and it provides guidance to the 
-Development Team on why it is building the Increment.
+####Topic One: What can be done this Sprint?
 
-Topic Two: How will the chosen work get done?
-Having set the Sprint Goal and selected the Product Backlog items for the Sprint, the
-Development Team decides how it will build this functionality into a “Done” product Increment
-during the Sprint. The Product Backlog items selected for this Sprint plus the plan for delivering
-them is called the Sprint Backlog.
-The Development Team usually starts by designing the system and the work needed to convert
-the Product Backlog into a working product Increment. Work may be of varying size, or
-estimated effort. However, enough work is planned during Sprint Planning for the Development
-Team to forecast what it believes it can do in the upcoming Sprint. Work planned for the first
-days of the Sprint by the Development Team is decomposed by the end of this meeting, often to
-units of one day or less. The Development Team self-organizes to undertake the work in the
-Sprint Backlog, both during Sprint Planning and as needed throughout the Sprint.
-The Product Owner can help to clarify the selected Product Backlog items and make trade-offs.
-If the Development Team determines it has too much or too little work, it may renegotiate the
-selected Product Backlog items with the Product Owner. The Development Team may also invite
-other people to attend to provide technical or domain advice.
-By the end of the Sprint Planning, the Development Team should be able to explain to the
-Product Owner and Scrum Master how it intends to work as a self-organizing team to
-accomplish the Sprint Goal and create the anticipated Increment.
+The Development Team works to forecast the functionality that will be developed during the Sprint. The Product Owner discusses the objective that the Sprint should achieve and the Product Backlog items that, if completed in the Sprint, would achieve the Sprint Goal. The entire Scrum Team collaborates on understanding the work of the Sprint.
 
-Sprint Goal
-The Sprint Goal is an objective set for the Sprint that can be met through the implementation of
-Product Backlog. It provides guidance to the Development Team on why it is building the
-Increment. It is created during the Sprint Planning meeting. The Sprint Goal gives the
-Development Team some flexibility regarding the functionality implemented within the Sprint.
-The selected Product Backlog items deliver one coherent function, which can be the Sprint Goal.
-The Sprint Goal can be any other coherence that causes the Development Team to work
-together rather than on separate initiatives.
-As the Development Team works, it keeps the Sprint Goal in mind. In order to satisfy the Sprint
-Goal, it implements functionality and technology. If the work turns out to be different than 
-the Development Team expected, they collaborate with the Product Owner to negotiate the 
-scope of Sprint Backlog within the Sprint. 
+The input to this meeting is the Product Backlog, the latest product Increment, projected capacity of the Development Team during the Sprint, and past performance of the Development Team. The number of items selected from the Product Backlog for the Sprint is solely up to the Development Team. Only the Development Team can assess what it can accomplish over the upcoming Sprint.
 
-Daily Scrum
-The Daily Scrum is a 15-minute time-boxed event for the Development Team. The Daily Scrum is
-held every day of the Sprint. At it, the Development Team plans work for the next 24 hours. This
-optimizes team collaboration and performance by inspecting the work since the last Daily Scrum
-and forecasting upcoming Sprint work. The Daily Scrum is held at the same time and place each
-day to reduce complexity.
-The Development Team uses the Daily Scrum to inspect progress toward the Sprint Goal and to
-inspect how progress is trending toward completing the work in the Sprint Backlog. The Daily
-Scrum optimizes the probability that the Development Team will meet the Sprint Goal. Every
-day, the Development Team should understand how it intends to work together as a selforganizing
-team to accomplish the Sprint Goal and create the anticipated Increment by the end
-of the Sprint.
-The structure of the meeting is set by the Development Team and can be conducted in different
-ways if it focuses on progress toward the Sprint Goal. Some Development Teams will use
-questions, some will be more discussion based. Here is an example of what might be used:
+During Sprint Planning the Scrum Team also crafts a Sprint Goal. The Sprint Goal is an objective that will be met within the Sprint through the implementation of the Product Backlog, and it provides guidance to the Development Team on why it is building the Increment.
+
+#### Topic Two: how will the chosen work get done?
+
+Having set the Sprint Goal and selected the Product Backlog items for the Sprint, the Development Team decides how it will build this functionality into a "Done" product Increment during the Sprint. The Product Backlog items selected for this Sprint plus the plan for delivering them is called the Sprint Backlog.
+
+The Development Team usually starts by designing the system and the work needed to convert the Product Backlog into a working product Increment. Work may be of varying size, or estimated effort. However, enough work is planned during Sprint Planning for the Development Team to forecast what it believes it can do in the upcoming Sprint. Work planned for the first days of the Sprint by the Development Team is decomposed by the end of this meeting, often to units of one day or less. The Development Team self-organizes to undertake the work in the Sprint Backlog, both during Sprint Planning and as needed throughout the Sprint.
+
+The Product Owner can help to clarify the selected Product Backlog items and make trade-offs. If the Development Team determines it has too much or too little work, it may renegotiate the selected Product Backlog items with the Product Owner. The Development Team may also invite other people to attend to provide technical or domain advice.
+
+By the end of the Sprint Planning, the Development Team should be able to explain to the Product Owner and Scrum Master how it intends to work as a self-organizing team to accomplish the Sprint Goal and create the anticipated Increment.
+
+#### Sprint Goal
+
+The Sprint Goal is an objective set for the Sprint that can be met through the implementation of Product Backlog. It provides guidance to the Development Team on why it is building the Increment. It is created during the Sprint Planning meeting. The Sprint Goal gives the Development Team some flexibility regarding the functionality implemented within the Sprint. The selected Product Backlog items deliver one coherent function, which can be the Sprint Goal. The Sprint Goal can be any other coherence that causes the Development Team to work together rather than on separate initiatives.
+
+As the Development Team works, it keeps the Sprint Goal in mind. In order to satisfy the Sprint Goal, it implements functionality and technology. If the work turns out to be different than the Development Team expected, they collaborate with the Product Owner to negotiate the scope of Sprint Backlog within the Sprint.
+
+### Daily Scrum
+
+The Daily Scrum is a 15-minute time-boxed event for the Development Team. The Daily Scrum is held every day of the Sprint. At it, the Development Team plans work for the next 24 hours. This optimizes team collaboration and performance by inspecting the work since the last Daily Scrum and forecasting upcoming Sprint work. The Daily Scrum is held at the same time and place each day to reduce complexity.
+
+The Development Team uses the Daily Scrum to inspect progress toward the Sprint Goal and to inspect how progress is trending toward completing the work in the Sprint Backlog. The Daily Scrum optimizes the probability that the Development Team will meet the Sprint Goal. Every day, the Development Team should understand how it intends to work together as a self-organizing team to accomplish the Sprint Goal and create the anticipated Increment by the end of the Sprint.
+
+The structure of the meeting is set by the Development Team and can be conducted in different ways if it focuses on progress toward the Sprint Goal. Some Development Teams will use questions, some will be more discussion based. Here is an example of what might be used:
+
 - What did I do yesterday that helped the Development Team meet the Sprint Goal?
 - What will I do today to help the Development Team meet the Sprint Goal?
-- Do I see any impediment that prevents me or the Development Team from meeting the
-Sprint Goal?
-The Development Team or team members often meet immediately after the Daily Scrum for
-detailed discussions, or to adapt, or replan, the rest of the Sprint’s work.
-The Scrum Master ensures that the Development Team has the meeting, but the Development
-Team is responsible for conducting the Daily Scrum. The Scrum Master teaches the
-Development Team to keep the Daily Scrum within the 15-minute time-box.
-The Daily Scrum is an internal meeting for the Development Team. If others are present, the
-Scrum Master ensures that they do not disrupt the meeting.
-Daily Scrums improve communications, eliminate other meetings, identify impediments to
-development for removal, highlight and promote quick decision-making, and improve the
-Development Team’s level of knowledge. This is a key inspect and adapt meeting.
-Sprint Review
-A Sprint Review is held at the end of the Sprint to inspect the Increment and adapt the Product
-Backlog if needed. During the Sprint Review, the Scrum Team and stakeholders collaborate
-about what was done in the Sprint. Based on that and any changes to the Product Backlog
-during the Sprint, attendees collaborate on the next things that could be done to optimize value.
-This is an informal meeting, not a status meeting, and the presentation of the Increment is
-intended to elicit feedback and foster collaboration.
-This is at most a four-hour meeting for one-month Sprints. For shorter Sprints, the event is
-usually shorter. The Scrum Master ensures that the event takes place and that attendees
-understand its purpose. The Scrum Master teaches everyone involved to keep it within the timebox.
-The Sprint Review includes the following elements:
-- Attendees include the Scrum Team and key stakeholders invited by the Product Owner;
-- The Product Owner explains what Product Backlog items have been “Done” and what has
-not been “Done”;
-- The Development Team discusses what went well during the Sprint, what problems it ran
-into, and how those problems were solved;
-- The Development Team demonstrates the work that it has “Done” and answers questions
-about the Increment;
-- The Product Owner discusses the Product Backlog as it stands. He or she projects likely
-target and delivery dates based on progress to date (if needed);
-- The entire group collaborates on what to do next, so that the Sprint Review provides
-valuable input to subsequent Sprint Planning;
-- Review of how the marketplace or potential use of the product might have changed what is
-the most valuable thing to do next; and,
-- Review of the timeline, budget, potential capabilities, and marketplace for the next
-anticipated releases of functionality or capability of the product.
-The result of the Sprint Review is a revised Product Backlog that defines the probable Product
-Backlog items for the next Sprint. The Product Backlog may also be adjusted overall to meet new
-opportunities.
+- Do I see any impediment that prevents me or the Development Team from meeting the Sprint Goal?
 
-Sprint Retrospective
-The Sprint Retrospective is an opportunity for the Scrum Team to inspect itself and create a plan
-for improvements to be enacted during the next Sprint.
-The Sprint Retrospective occurs after the Sprint Review and prior to the next Sprint Planning.
-This is at most a three-hour meeting for one-month Sprints. For shorter Sprints, the event is
-usually shorter. The Scrum Master ensures that the event takes place and that attendants
-understand its purpose.
-The Scrum Master ensures that the meeting is positive and productive. The Scrum Master
-teaches all to keep it within the time-box. The Scrum Master participates as a peer team
-member in the meeting from the accountability over the Scrum process.
+The Development Team or team members often meet immediately after the Daily Scrum for detailed discussions, or to adapt, or replan, the rest of the Sprint’s work.
+
+The Scrum Master ensures that the Development Team has the meeting, but the Development Team is responsible for conducting the Daily Scrum. The Scrum Master teaches the Development Team to keep the Daily Scrum within the 15-minute time-box.
+
+The Daily Scrum is an internal meeting for the Development Team. If others are present, the Scrum Master ensures that they do not disrupt the meeting.
+
+Daily Scrums improve communications, eliminate other meetings, identify impediments to development for removal, highlight and promote quick decision-making, and improve the Development Team’s level of knowledge. This is a key inspect and adapt meeting.
+
+### Sprint Review
+
+A Sprint Review is held at the end of the Sprint to inspect the Increment and adapt the Product Backlog if needed. During the Sprint Review, the Scrum Team and stakeholders collaborate about what was done in the Sprint. Based on that and any changes to the Product Backlog during the Sprint, attendees collaborate on the next things that could be done to optimize value. This is an informal meeting, not a status meeting, and the presentation of the Increment is intended to elicit feedback and foster collaboration.
+
+This is at most a four-hour meeting for one-month Sprints. For shorter Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and that attendees understand its purpose. The Scrum Master teaches everyone involved to keep it within the time-box.
+
+The Sprint Review includes the following elements:
+
+- Attendees include the Scrum Team and key stakeholders invited by the Product Owner;
+- The Product Owner explains what Product Backlog items have been "Done" and what has not been "Done";
+- The Development Team discusses what went well during the Sprint, what problems it ran into, and how those problems were solved;
+- The Development Team demonstrates the work that it has "Done" and answers questions about the Increment;
+- The Product Owner discusses the Product Backlog as it stands. He or she projects likely target and delivery dates based on progress to date (if needed);
+- The entire group collaborates on what to do next, so that the Sprint Review provides valuable input to subsequent Sprint Planning;
+- Review of how the marketplace or potential use of the product might have changed what is the most valuable thing to do next; and,
+- Review of the timeline, budget, potential capabilities, and marketplace for the next anticipated releases of functionality or capability of the product.
+
+The result of the Sprint Review is a revised Product Backlog that defines the probable Product Backlog items for the next Sprint. The Product Backlog may also be adjusted overall to meet new opportunities.
+
+### Sprint Retrospective
+
+The Sprint Retrospective is an opportunity for the Scrum Team to inspect itself and create a plan for improvements to be enacted during the next Sprint.
+
+The Sprint Retrospective occurs after the Sprint Review and prior to the next Sprint Planning. This is at most a three-hour meeting for one-month Sprints. For shorter Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and that attendants understand its purpose.
+
+The Scrum Master ensures that the meeting is positive and productive. The Scrum Master teaches all to keep it within the time-box. The Scrum Master participates as a peer team member in the meeting from the accountability over the Scrum process.
+
 The purpose of the Sprint Retrospective is to:
+
 - Inspect how the last Sprint went with regards to people, relationships, process, and tools;
 - Identify and order the major items that went well and potential improvements; and,
 - Create a plan for implementing improvements to the way the Scrum Team does its work.
-The Scrum Master encourages the Scrum Team to improve, within the Scrum process
-framework, its development process and practices to make it more effective and enjoyable for
-the next Sprint. During each Sprint Retrospective, the Scrum Team plans ways to increase
-product quality by improving work processes or adapting the definition of “Done”, if appropriate
-and not in conflict with product or organizational standards.
-By the end of the Sprint Retrospective, the Scrum Team should have identified improvements
-that it will implement in the next Sprint. Implementing these improvements in the next Sprint is
-the adaptation to the inspection of the Scrum Team itself. Although improvements may be
-implemented at any time, the Sprint Retrospective provides a formal opportunity to focus on
-inspection and adaptation.
 
-Scrum Artifacts
-Scrum’s artifacts represent work or value to provide transparency and opportunities for
-inspection and adaptation. Artifacts defined by Scrum are specifically designed to maximize
-transparency of key information so that everybody has the same understanding of the artifact.
+The Scrum Master encourages the Scrum Team to improve, within the Scrum process framework, its development process and practices to make it more effective and enjoyable for the next Sprint. During each Sprint Retrospective, the Scrum Team plans ways to increase product quality by improving work processes or adapting the definition of "Done", if appropriate and not in conflict with product or organizational standards.
 
-Product Backlog
-The Product Backlog is an ordered list of everything that is known to be needed in the product.
-It is the single source of requirements for any changes to be made to the product. The Product
-Owner is responsible for the Product Backlog, including its content, availability, and ordering.
-A Product Backlog is never complete. The earliest development of it lays out the initially known
-and best-understood requirements. The Product Backlog evolves as the product and the
-environment in which it will be used evolves. The Product Backlog is dynamic; it constantly
-changes to identify what the product needs to be appropriate, competitive, and useful. If a
-product exists, its Product Backlog also exists.
-The Product Backlog lists all features, functions, requirements, enhancements, and fixes that
-constitute the changes to be made to the product in future releases. Product Backlog items have
-the attributes of a description, order, estimate, and value.
-Product Backlog items often include test descriptions that will prove its completeness when “Done.”
-As a product is used and gains value, and the marketplace provides feedback, the Product
-Backlog becomes a larger and more exhaustive list. Requirements never stop changing, so a
-Product Backlog is a living artifact. Changes in business requirements, market conditions, or
-technology may cause changes in the Product Backlog.
-Multiple Scrum Teams often work together on the same product. One Product Backlog is used
-to describe the upcoming work on the product. A Product Backlog attribute that groups items
-may then be employed.
+By the end of the Sprint Retrospective, the Scrum Team should have identified improvements that it will implement in the next Sprint. Implementing these improvements in the next Sprint is the adaptation to the inspection of the Scrum Team itself. Although improvements may be implemented at any time, the Sprint Retrospective provides a formal opportunity to focus on inspection and adaptation.
 
-Product Backlog refinement is the act of adding detail, estimates, and order to items in the
-Product Backlog. This is an ongoing process in which the Product Owner and the Development
-Team collaborate on the details of Product Backlog items. During Product Backlog refinement,
-items are reviewed and revised. The Scrum Team decides how and when refinement is done.
-Refinement usually consumes no more than 10% of the capacity of the Development Team.
-However, Product Backlog items can be updated at any time by the Product Owner or at the
-Product Owner’s discretion.
-Higher ordered Product Backlog items are usually clearer and more detailed than lower ordered
-ones. More precise estimates are made based on the greater clarity and increased detail; the
-lower the order, the less detail. Product Backlog items that will occupy the Development Team
-for the upcoming Sprint are refined so that any one item can reasonably be “Done” within the
-Sprint time-box. Product Backlog items that can be “Done” by the Development Team within
-one Sprint are deemed “Ready” for selection in a Sprint Planning. Product Backlog items usually
-acquire this degree of transparency through the above described refining activities.
-The Development Team is responsible for all estimates. The Product Owner may influence the
-Development Team by helping it understand and select trade-offs, but the people who will
-perform the work make the final estimate.
-Monitoring Progress Toward Goals
-At any point in time, the total work remaining to reach a goal can be summed. The Product
-Owner tracks this total work remaining at least every Sprint Review. The Product Owner
-compares this amount with work remaining at previous Sprint Reviews to assess progress
-toward completing projected work by the desired time for the goal. This information is made
-transparent to all stakeholders.
-Various projective practices upon trending have been used to forecast progress, like burndowns, burn-ups, or cumulative flows. These have proven useful. However, these do not replace
-the importance of empiricism. In complex environments, what will happen is unknown. Only
-what has already happened may be used for forward-looking decision-making.
+##Scrum Artifacts
 
-Sprint Backlog
-The Sprint Backlog is the set of Product Backlog items selected for the Sprint, plus a plan for
-delivering the product Increment and realizing the Sprint Goal. The Sprint Backlog is a forecast
-by the Development Team about what functionality will be in the next Increment and the work
-needed to deliver that functionality into a “Done” Increment.
-The Sprint Backlog makes visible all the work that the Development Team identifies as necessary
-to meet the Sprint Goal. 
-To ensure continuous improvement, it includes at least one high
-priority process improvement identified in the previous Retrospective meeting.
-The Sprint Backlog is a plan with enough detail that changes in progress can be understood in
-the Daily Scrum. The Development Team modifies the Sprint Backlog throughout the Sprint, and
-the Sprint Backlog emerges during the Sprint. This emergence occurs as the Development Team
-works through the plan and learns more about the work needed to achieve the Sprint Goal.
-As new work is required, the Development Team adds it to the Sprint Backlog. As work is
-performed or completed, the estimated remaining work is updated. When elements of the plan
-are deemed unnecessary, they are removed. Only the Development Team can change its Sprint
-Backlog during a Sprint. The Sprint Backlog is a highly visible, real-time picture of the work that
-the Development Team plans to accomplish during the Sprint, and it belongs solely to the
-Development Team.
-Monitoring Sprint Progress
-At any point in time in a Sprint, the total work remaining in the Sprint Backlog can be summed.
-The Development Team tracks this total work remaining at least for every Daily Scrum to project
-the likelihood of achieving the Sprint Goal. By tracking the remaining work throughout the
-Sprint, the Development Team can manage its progress.
-Increment
-The Increment is the sum of all the Product Backlog items completed during a Sprint and the
-value of the increments of all previous Sprints. At the end of a Sprint, the new Increment must
-be “Done,” which means it must be in useable condition and meet the Scrum Team’s definition
-of “Done.” An increment is a body of inspectable, done work that supports empiricism at the
-end of the Sprint. The increment is a step toward a vision or goal. The increment must be in
-useable condition regardless of whether the Product Owner decides to release it.
-Artifact Transparency
-Scrum relies on transparency. Decisions to optimize value and control risk are made based on
-the perceived state of the artifacts. To the extent that transparency is complete, these decisions
-have a sound basis. To the extent that the artifacts are incompletely transparent, these
-decisions can be flawed, value may diminish and risk may increase.
-The Scrum Master must work with the Product Owner, Development Team, and other involved
-parties to understand if the artifacts are completely transparent. There are practices for coping
-with incomplete transparency; the Scrum Master must help everyone apply the most
-appropriate practices in the absence of complete transparency. A Scrum Master can detect
-incomplete transparency by inspecting the artifacts, sensing patterns, listening closely to what is
-being said, and detecting differences between expected and real results.
-The Scrum Master’s job is to work with the Scrum Team and the organization to increase the
-transparency of the artifacts. This work usually involves learning, convincing, and change.
-Transparency doesn’t occur overnight, but is a path.
-Definition of “Done”
-When a Product Backlog item or an Increment is described as “Done”, everyone must
-understand what “Done” means. Although this may vary significantly per Scrum Team, members
-must have a shared understanding of what it means for work to be complete, to ensure
-transparency. This is the definition of “Done” for the Scrum Team and is used to assess when
-work is complete on the product Increment.
-The same definition guides the Development Team in knowing how many Product Backlog items
-it can select during a Sprint Planning. The purpose of each Sprint is to deliver Increments of
-potentially releasable functionality that adhere to the Scrum Team’s current definition of
-“Done.”
-Development Teams deliver an Increment of product functionality every Sprint. This Increment
-is useable, so a Product Owner may choose to immediately release it. If the definition of "Done"
-for an increment is part of the conventions, standards or guidelines of the development
-organization, all Scrum Teams must follow it as a minimum. If "Done" for an increment is not a 
-convention of the development organization, the
-Development Team of the Scrum Team must define a definition of “Done” appropriate for the
-product. If there are multiple Scrum Teams working on the system or product release, the
-Development Teams on all the Scrum Teams must mutually define the definition of “Done.”
-Each Increment is additive to all prior Increments and thoroughly tested, ensuring that all
-Increments work together.
-As Scrum Teams mature, it is expected that their definitions of “Done” will expand to include
-more stringent criteria for higher quality. New definitions, as used, may uncover work to be
-done in previously “Done” increments. Any one product or system should have a definition of
-“Done” that is a standard for any work done on it.
+Scrum’s artifacts represent work or value to provide transparency and opportunities for inspection and adaptation. Artifacts defined by Scrum are specifically designed to maximize transparency of key information so that everybody has the same understanding of the artifact.
 
-End Note
-Scrum is free and offered in this Guide. Scrum’s roles, events, artifacts, and rules are immutable
-and although implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists
-only in its entirety and functions well as a container for other techniques, methodologies, and
-practices.
-Acknowledgements
-People
-Of the thousands of people who have contributed to Scrum, we should single out those who
-were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John
-Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them
-worked together. Many others contributed in the ensuing years and without their help Scrum
-would not be refined as it is today.
-History
-Ken Schwaber and Jeff Sutherland worked on Scrum until 1995, when they co-presented Scrum
-at the OOPSLA Conference in 1995. This presentation essentially documented the learning that
-Ken and Jeff gained over the previous few years, and made public the first formal definition of
-Scrum.
-The history of Scrum is described elsewhere. To honor the first places where it was tried and
-refined, we recognize Individual, Inc., Newspage, Fidelity Investments, and IDX (now GE
-Medical).
-The Scrum Guide documents Scrum as developed, evolved, and sustained for 20-plus years by
-Jeff Sutherland and Ken Schwaber. Other sources provide you with patterns, processes, and
-insights that complement the Scrum framework. These may increase productivity, value,
-creativity, and satisfaction with the results.
+### Product Backlog
+
+The Product Backlog is an ordered list of everything that is known to be needed in the product. It is the single source of requirements for any changes to be made to the product. The Product Owner is responsible for the Product Backlog, including its content, availability, and ordering.
+
+A Product Backlog is never complete. The earliest development of it lays out the initially known and best-understood requirements. The Product Backlog evolves as the product and the environment in which it will be used evolves. The Product Backlog is dynamic; it constantly changes to identify what the product needs to be appropriate, competitive, and useful. If a product exists, its Product Backlog also exists.
+
+The Product Backlog lists all features, functions, requirements, enhancements, and fixes that constitute the changes to be made to the product in future releases. Product Backlog items have the attributes of a description, order, estimate, and value. Product Backlog items often include test descriptions that will prove its completeness when "Done".
+
+As a product is used and gains value, and the marketplace provides feedback, the Product Backlog becomes a larger and more exhaustive list. Requirements never stop changing, so a Product Backlog is a living artifact. Changes in business requirements, market conditions, or technology may cause changes in the Product Backlog.
+
+Multiple Scrum Teams often work together on the same product. One Product Backlog is used to describe the upcoming work on the product. A Product Backlog attribute that groups items may then be employed.
+
+Product Backlog refinement is the act of adding detail, estimates, and order to items in the Product Backlog. This is an ongoing process in which the Product Owner and the Development Team collaborate on the details of Product Backlog items. During Product Backlog refinement, items are reviewed and revised. The Scrum Team decides how and when refinement is done. Refinement usually consumes no more than 10% of the capacity of the Development Team. However, Product Backlog items can be updated at any time by the Product Owner or at the Product Owner’s discretion.
+
+Higher ordered Product Backlog items are usually clearer and more detailed than lower ordered ones. More precise estimates are made based on the greater clarity and increased detail; the lower the order, the less detail. Product Backlog items that will occupy the Development Team for the upcoming Sprint are refined so that any one item can reasonably be "Done" within the Sprint time-box. Product Backlog items that can be "Done" by the Development Team within one Sprint are deemed "Ready" for selection in a Sprint Planning. Product Backlog items usually acquire this degree of transparency through the above described refining activities.
+
+The Development Team is responsible for all estimates. The Product Owner may influence the Development Team by helping it understand and select trade-offs, but the people who will perform the work make the final estimate.
+
+#### Monitoring Progress Toward Goals
+
+At any point in time, the total work remaining to reach a goal can be summed. The Product Owner tracks this total work remaining at least every Sprint Review. The Product Owner compares this amount with work remaining at previous Sprint Reviews to assess progress toward completing projected work by the desired time for the goal. This information is made transparent to all stakeholders.
+
+Various projective practices upon trending have been used to forecast progress, like burn-downs, burn-ups, or cumulative flows. These have proven useful. However, these do not replace the importance of empiricism. In complex environments, what will happen is unknown. Only what has already happened may be used for forward-looking decision-making.
+
+### Sprint Backlog
+
+The Sprint Backlog is the set of Product Backlog items selected for the Sprint, plus a plan for delivering the product Increment and realizing the Sprint Goal. The Sprint Backlog is a forecast by the Development Team about what functionality will be in the next Increment and the work needed to deliver that functionality into a "Done" Increment.
+
+The Sprint Backlog makes visible all the work that the Development Team identifies as necessary to meet the Sprint Goal. To ensure continuous improvement, it includes at least one high priority process improvement identified in the previous Retrospective meeting.
+
+The Sprint Backlog is a plan with enough detail that changes in progress can be understood in the Daily Scrum. The Development Team modifies the Sprint Backlog throughout the Sprint, and the Sprint Backlog emerges during the Sprint. This emergence occurs as the Development Team works through the plan and learns more about the work needed to achieve the Sprint Goal.
+
+As new work is required, the Development Team adds it to the Sprint Backlog. As work is performed or completed, the estimated remaining work is updated. When elements of the plan are deemed unnecessary, they are removed. Only the Development Team can change its Sprint Backlog during a Sprint. The Sprint Backlog is a highly visible, real-time picture of the work that the Development Team plans to accomplish during the Sprint, and it belongs solely to the Development Team.
+
+#### Monitoring Sprint Progress
+
+At any point in time in a Sprint, the total work remaining in the Sprint Backlog can be summed. The Development Team tracks this total work remaining at least for every Daily Scrum to project the likelihood of achieving the Sprint Goal. By tracking the remaining work throughout the Sprint, the Development Team can manage its progress.
+
+### Increment
+
+The Increment is the sum of all the Product Backlog items completed during a Sprint and the value of the increments of all previous Sprints. At the end of a Sprint, the new Increment must be "Done," which means it must be in useable condition and meet the Scrum Team’s definition of "Done". An increment is a body of inspectable, done work that supports empiricism at the end of the Sprint. The increment is a step toward a vision or goal. The increment must be in useable condition regardless of whether the Product Owner decides to release it.
+
+## Artifact Transparency
+
+Scrum relies on transparency. Decisions to optimize value and control risk are made based on the perceived state of the artifacts. To the extent that transparency is complete, these decisions have a sound basis. To the extent that the artifacts are incompletely transparent, these decisions can be flawed, value may diminish and risk may increase.
+
+The Scrum Master must work with the Product Owner, Development Team, and other involved parties to understand if the artifacts are completely transparent. There are practices for coping with incomplete transparency; the Scrum Master must help everyone apply the most appropriate practices in the absence of complete transparency. A Scrum Master can detect incomplete transparency by inspecting the artifacts, sensing patterns, listening closely to what is being said, and detecting differences between expected and real results.
+
+The Scrum Master’s job is to work with the Scrum Team and the organization to increase the transparency of the artifacts. This work usually involves learning, convincing, and change. Transparency doesn’t occur overnight, but is a path.
+
+### Definition of "Done"
+
+When a Product Backlog item or an Increment is described as "Done", everyone must understand what "Done" means. Although this may vary significantly per Scrum Team, members must have a shared understanding of what it means for work to be complete, to ensure transparency. This is the definition of "Done" for the Scrum Team and is used to assess when work is complete on the product Increment.
+
+The same definition guides the Development Team in knowing how many Product Backlog items it can select during a Sprint Planning. The purpose of each Sprint is to deliver Increments of potentially releasable functionality that adhere to the Scrum Team’s current definition of "Done".
+
+Development Teams deliver an Increment of product functionality every Sprint. This Increment is useable, so a Product Owner may choose to immediately release it. If the definition of "Done" for an increment is part of the conventions, standards or guidelines of the development organization, all Scrum Teams must follow it as a minimum.
+
+If "Done" for an increment is not a convention of the development organization, the Development Team of the Scrum Team must define a definition of "Done" appropriate for the product. If there are multiple Scrum Teams working on the system or product release, the Development Teams on all the Scrum Teams must mutually define the definition of "Done".
+
+Each Increment is additive to all prior Increments and thoroughly tested, ensuring that all Increments work together.
+
+As Scrum Teams mature, it is expected that their definitions of "Done" will expand to include more stringent criteria for higher quality. New definitions, as used, may uncover work to be done in previously "Done" increments. Any one product or system should have a definition of "Done" that is a standard for any work done on it.
+
+## End Note
+
+Scrum is free and offered in this Guide. Scrum’s roles, events, artifacts, and rules are immutable and although implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists only in its entirety and functions well as a container for other techniques, methodologies, and practices.
+
+## Acknowledgements
+
+### People
+
+Of the thousands of people who have contributed to Scrum, we should single out those who were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them worked together. Many others contributed in the ensuing years and without their help Scrum would not be refined as it is today.
+
+### History
+
+Ken Schwaber and Jeff Sutherland worked on Scrum until 1995, when they co-presented Scrum at the OOPSLA Conference in 1995. This presentation essentially documented the learning that Ken and Jeff gained over the previous few years, and made public the first formal definition of Scrum.
+
+The history of Scrum is described elsewhere. To honor the first places where it was tried and refined, we recognize Individual, Inc., Newspage, Fidelity Investments, and IDX (now GE Health).
+
+The Scrum Guide documents Scrum as developed, evolved, and sustained for 20-plus years by Jeff Sutherland and Ken Schwaber. Other sources provide you with patterns, processes, and insights that complement the Scrum framework. These may increase productivity, value, creativity, and satisfaction with the results.
+
+©2018 Ken Schwaber and Jeff Sutherland. Offered for license under the Attribution Share-Alike license of Creative Commons, accessible at http://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary form at http://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide you acknowledge and agree that you have read and agree to be bound by the terms of the Attribution ShareAlike license of Creative Commons.

--- a/scrum guide
+++ b/scrum guide
@@ -1,300 +1,536 @@
-﻿# The Scrum Guide
+﻿The Scrum Guide
+The Definitive Guide to Scrum:
+The Rules of the Game
 
-Ken Schwaber & Jeff Sutherland
-The Definitive Guide to Scrum: The Rules of the Game
-November 2020
+November 2017
 
-## Purpose of the Scrum Guide
+Developed and sustained by Scrum creators: Ken Schwaber and Jeff Sutherland
 
-We developed Scrum in the early 1990s. We wrote the first version of the Scrum Guide in 2010 to help people worldwide understand Scrum. We have evolved the Guide since then through small, functional updates. Together, we stand behind it.
+Purpose of the Scrum Guide
+Scrum is a framework for developing, delivering, and sustaining complex products. This Guide contains the
+definition of Scrum. This definition consists of Scrum’s roles, events, artifacts, and the rules that 
+bind them together. Ken Schwaber and Jeff Sutherland developed Scrum; the Scrum Guide is 
+written and provided by them. Together, they stand behind the Scrum Guide.
+Definition of Scrum
+Scrum (n): A framework within which people can address complex adaptive problems, while
+productively and creatively delivering products of the highest possible value.
+Scrum is:
+- Lightweight
+- Simple to understand
+- Difficult to master
+Scrum is a process framework that has been used to manage work on complex products 
+since the early 1990s. Scrum is not a process, technique, or definitive method. Rather, it is a
+framework within which you can employ various processes and techniques. Scrum makes clear
+the relative efficacy of your product management and work techniques so that you can
+continuously improve the product, the team, and the working environment.
+The Scrum framework consists of Scrum Teams and their associated roles, events, artifacts, and
+rules. Each component within the framework serves a specific purpose and is essential to
+Scrum’s success and usage.
+The rules of Scrum bind together the roles, events, and artifacts, governing the relationships and
+interaction between them. The rules of Scrum are described throughout the body of this
+document.
+Specific tactics for using the Scrum framework vary and are described elsewhere.
 
-The Scrum Guide contains the definition of Scrum. Each element of the framework serves a specific purpose that is essential to the overall value and results realized with Scrum. Changing the core design or ideas of Scrum, leaving out elements, or not following the rules of Scrum, covers up problems and limits the benefits of Scrum, potentially even rendering it useless.
+Uses of Scrum
+Scrum was initially developed for managing and developing products. Starting in the early
+1990s, Scrum has been used extensively, worldwide, to:
+1. Research and identify viable markets, technologies, and product capabilities;
+2. Develop products and enhancements;
+3. Release products and enhancements, as frequently as many times per day;
+4. Develop and sustain Cloud (online, secure, on-demand) and other operational
+environments for product use; and,
+5. Sustain and renew products.
+Scrum has been used to develop software, hardware, embedded software, networks of
+interacting function, autonomous vehicles, schools, government, marketing, managing the
+operation of organizations and almost everything we use in our daily lives, as individuals and
+societies.
+As technology, market, and environmental complexities and their interactions have rapidly
+increased, Scrum’s utility in dealing with complexity is proven daily.
+Scrum proved especially effective in iterative and incremental knowledge transfer. Scrum is now
+widely used for products, services, and the management of the parent organization.
+The essence of Scrum is a small team of people. The individual team is highly flexible and
+adaptive. These strengths continue operating in single, several, many, and networks of teams
+that develop, release, operate and sustain the work and work products of thousands of people.
+They collaborate and interoperate through sophisticated development architectures and target
+release environments.
+When the words “develop” and “development” are used in the Scrum Guide, they refer to
+complex work, such as those types identified above.
 
-We follow the growing use of Scrum within an ever-growing complex world. We are humbled to see Scrum being adopted in many domains holding essentially complex work, beyond software product development where Scrum has its roots. As Scrum’s use spreads, developers, researchers, analysts, scientists, and other specialists do the work. We use the word “developers” in Scrum not to exclude, but to simplify. If you get value from Scrum, consider yourself included.
 
-As Scrum is being used, patterns, processes, and insights that fit the Scrum framework as described in this document, may be found, applied and devised. Their description is beyond the purpose of the Scrum Guide because they are context sensitive and differ widely between Scrum uses. Such tactics for using within the Scrum framework vary widely and are described elsewhere.
+Scrum Theory
+Scrum is founded on empirical process control theory, or empiricism. Empiricism asserts that
+knowledge comes from experience and making decisions based on what is known. Scrum
+employs an iterative, incremental approach to optimize predictability and control risk.
+Three pillars uphold every implementation of empirical process control: transparency,
+inspection, and adaptation.
 
-## Scrum Definition
+Transparency
+Significant aspects of the process must be visible to those responsible for the outcome.
+Transparency requires those aspects be defined by a common standard so observers share a
+common understanding of what is being seen.
+For example
+- A common language referring to the process must be shared by all participants; and,
+- Those performing the work and those inspecting the resulting increment must share a
+common definition of “Done”.
+Inspection
+Scrum users must frequently inspect Scrum artifacts and progress toward a Sprint Goal to detect
+undesirable variances. Their inspection should not be so frequent that inspection gets in the way
+of the work. Inspections are most beneficial when diligently performed by skilled inspectors at
+the point of work.
+Adaptation
+If an inspector determines that one or more aspects of a process deviate outside acceptable
+limits, and that the resulting product will be unacceptable, the process or the material being
+processed must be adjusted. An adjustment must be made as soon as possible to minimize
+further deviation.
+Scrum prescribes four formal events for inspection and adaptation, as described in the Scrum
+Events section of this document:
+- Sprint Planning
+- Daily Scrum
+- Sprint Review
+- Sprint Retrospective
+Scrum Values
+When the values of commitment, courage, focus, openness and respect are embodied and lived
+by the Scrum Team, the Scrum pillars of transparency, inspection, and adaptation come to life
+and build trust for everyone. The Scrum Team members learn and explore those values as they
+work with the Scrum roles, events, and artifacts.
+Successful use of Scrum depends on people becoming more proficient in living these five values.
+People personally commit to achieving the goals of the Scrum Team. The Scrum Team members
+have courage to do the right thing and work on tough problems. Everyone focuses on the work
+of the Sprint and the goals of the Scrum Team. The Scrum Team and its stakeholders agree to be
+open about all the work and the challenges with performing the work. Scrum Team members
+respect each other to be capable, independent people.
 
-Scrum is a lightweight framework that helps people, teams and organizations generate value through adaptive solutions for complex problems.
 
-In a nutshell, Scrum requires a Scrum Master to foster an environment where:
+The Scrum Team
+The Scrum Team consists of a Product Owner, the Development Team, and a Scrum Master.
+Scrum Teams are self-organizing and cross-functional. Self-organizing teams choose how best to
+accomplish their work, rather than being directed by others outside the team. Cross-functional
+teams have all competencies needed to accomplish the work without depending on others not
+part of the team. The team model in Scrum is designed to optimize flexibility, creativity, and
+productivity. The Scrum Team has proven itself to be increasingly effective for all the earlier
+stated uses, and any complex work.
+Scrum Teams deliver products iteratively and incrementally, maximizing opportunities for
+feedback. Incremental deliveries of “Done” product ensure a potentially useful version of
+working product is always available.
+The Product Owner
+The Product Owner is responsible for maximizing the value of the product resulting from work
+of the Development Team. How this is done may vary widely across organizations, Scrum Teams,
+and individuals.
+The Product Owner is the sole person responsible for managing the Product Backlog. Product
+Backlog management includes:
+- Clearly expressing Product Backlog items;
+- Ordering the items in the Product Backlog to best achieve goals and missions;
+- Optimizing the value of the work the Development Team performs;
+- Ensuring that the Product Backlog is visible, transparent, and clear to all, and shows what
+the Scrum Team will work on next; and,
+- Ensuring the Development Team understands items in the Product Backlog to the level
+needed.
+The Product Owner may do the above work, or have the Development Team do it. However, the
+Product Owner remains accountable.
+The Product Owner is one person, not a committee. The Product Owner may represent the
+desires of a committee in the Product Backlog, but those wanting to change a Product Backlog
+item’s priority must address the Product Owner.
+For the Product Owner to succeed, the entire organization must respect his or her decisions. The
+Product Owner’s decisions are visible in the content and ordering of the Product Backlog. No
+one can force the Development Team to work from a different set of requirements.
 
-1. A Product Owner orders the work for a complex problem into a Product Backlog.
-2. The Scrum Team turns a selection of the work into an Increment of value during a Sprint.
-3. The Scrum Team and its stakeholders inspect the results and adjust for the next Sprint.
-4. _Repeat_
 
-Scrum is simple. Try it as is and determine if its philosophy, theory, and structure help to achieve goals and create value. The Scrum framework is purposefully incomplete, only defining the parts required to implement Scrum theory. Scrum is built upon by the collective intelligence of the people using it. Rather than provide people with detailed instructions, the rules of Scrum guide their relationships and interactions.
+The Development Team
+The Development Team consists of professionals who do the work of delivering a potentially
+releasable Increment of “Done” product at the end of each Sprint. A “Done” increment is
+required at the Sprint Review. Only members of the Development Team create the Increment.
+Development Teams are structured and empowered by the organization to organize and
+manage their own work. The resulting synergy optimizes the Development Team’s overall
+efficiency and effectiveness.
+Development Teams have the following characteristics:
+- They are self-organizing. No one (not even the Scrum Master) tells the Development Team
+how to turn Product Backlog into Increments of potentially releasable functionality;
+- Development Teams are cross-functional, with all the skills as a team necessary to create
+a product Increment;
+- Scrum recognizes no titles for Development Team members, regardless of the work being
+performed by the person;
+- Scrum recognizes no sub-teams in the Development Team, regardless of domains that need
+to be addressed like testing, architecture, operations, or business analysis; and,
+- Individual Development Team members may have specialized skills and areas of focus, but
+accountability belongs to the Development Team as a whole.
+Development Team Size
+Optimal Development Team size is small enough to remain nimble and large enough to
+complete significant work within a Sprint. Fewer than three Development Team members
+decrease interaction and results in smaller productivity gains. Smaller Development Teams may
+encounter skill constraints during the Sprint, causing the Development Team to be unable to
+deliver a potentially releasable Increment. Having more than nine members requires too much
+coordination. Large Development Teams generate too much complexity for an empirical process
+to be useful. The Product Owner and Scrum Master roles are not included in this count unless
+they are also executing the work of the Sprint Backlog.
+The Scrum Master
+The Scrum Master is responsible for promoting and supporting Scrum as defined in the Scrum
+Guide. Scrum Masters do this by helping everyone understand Scrum theory, practices, rules,
+and values.
+The Scrum Master is a servant-leader for the Scrum Team. The Scrum Master helps those
+outside the Scrum Team understand which of their interactions with the Scrum Team are helpful
+and which aren’t. The Scrum Master helps everyone change these interactions to maximize the
+value created by the Scrum Team.
 
-Various processes, techniques and methods can be employed within the framework. Scrum wraps around existing practices or renders them unnecessary. Scrum makes visible the relative efficacy of current management, environment, and work techniques, so that improvements can be made.
-
-## Scrum Theory
-
-Scrum is founded on empiricism and lean thinking. Empiricism asserts that knowledge comes from experience and making decisions based on what is observed. Lean thinking reduces waste and focuses on the essentials.
-
-Scrum employs an iterative, incremental approach to optimize predictability and to control risk. Scrum engages groups of people who collectively have all the skills and expertise to do the work and share or acquire such skills as needed.
-
-Scrum combines four formal events for inspection and adaptation within a containing event, the Sprint. These events work because they implement the empirical Scrum pillars of transparency, inspection, and adaptation.
-
-### Transparency
-
-The emergent process and work must be visible to those performing the work as well as those receiving the work. With Scrum, important decisions are based on the perceived state of its three formal artifacts. Artifacts that have low transparency can lead to decisions that diminish value and increase risk.
-
-Transparency enables inspection. Inspection without transparency is misleading and wasteful.
-
-### Inspection
-
-The Scrum artifacts and the progress toward agreed goals must be inspected frequently and diligently to detect potentially undesirable variances or problems. To help with inspection, Scrum provides cadence in the form of its five events.
-
-Inspection enables adaptation. Inspection without adaptation is considered pointless. Scrum events are designed to provoke change.
-
-### Adaptation
-
-If any aspects of a process deviate outside acceptable limits or if the resulting product is unacceptable, the process being applied or the materials being produced must be adjusted. The adjustment must be made as soon as possible to minimize further deviation.
-
-Adaptation becomes more difficult when the people involved are not empowered or self-managing. A Scrum Team is expected to adapt the moment it learns anything new through inspection.
-
-## Scrum Values
-
-Successful use of Scrum depends on people becoming more proficient in living five values:
-
-***Commitment, Focus, Openness, Respect, and Courage***
-
-The Scrum Team commits to achieving its goals and to supporting each other. Their primary focus is on the work of the Sprint to make the best possible progress toward these goals. The Scrum Team and its stakeholders are open about the work and the challenges. Scrum Team members respect each other to be capable, independent people, and are respected as such by the people with whom they work. The Scrum Team members have the courage to do the right thing, to work on tough problems.
-
-These values give direction to the Scrum Team with regard to their work, actions, and behavior. The decisions that are made, the steps taken, and the way Scrum is used should reinforce these values, not diminish or undermine them. The Scrum Team members learn and explore the values as they work with the Scrum events and artifacts. When these values are embodied by the Scrum Team and the people they work with, the empirical Scrum pillars of transparency, inspection, and adaptation come to life building trust.
-
-## Scrum Team
-
-The fundamental unit of Scrum is a small team of people, a Scrum Team. The Scrum Team consists of one Scrum Master, one Product Owner, and Developers. Within a Scrum Team, there are no sub-teams or hierarchies. It is a cohesive unit of professionals focused on one objective at a time, the Product Goal.
-
-Scrum Teams are cross-functional, meaning the members have all the skills necessary to create value each Sprint. They are also self-managing, meaning they internally decide who does what, when, and how.
-
-The Scrum Team is small enough to remain nimble and large enough to complete significant work within a Sprint, typically 10 or fewer people. In general, we have found that smaller teams communicate better and are more productive. If Scrum Teams become too large, they should consider reorganizing into multiple cohesive Scrum Teams, each focused on the same product. Therefore, they should share the same Product Goal, Product Backlog, and Product Owner.
-
-The Scrum Team is responsible for all product-related activities from stakeholder collaboration, verification, maintenance, operation, experimentation, research and development, and anything else that might be required. They are structured and empowered by the organization to manage their own work. Working in Sprints at a sustainable pace improves the Scrum Team’s focus and consistency.
-
-The entire Scrum Team is accountable for creating a valuable, useful Increment every Sprint. Scrum defines three specific accountabilities within the Scrum Team: the Developers, the Product Owner, and the Scrum Master.
-
-### Developers
-
-Developers are the people in the Scrum Team that are committed to creating any aspect of a usable Increment each Sprint.
-
-The specific skills needed by the Developers are often broad and will vary with the domain of work. However, the Developers are always accountable for:
-
-- Creating a plan for the Sprint, the Sprint Backlog;
-- Instilling quality by adhering to a Definition of Done;
-- Adapting their plan each day toward the Sprint Goal; and,
-- Holding each other accountable as professionals.
-
-### Product Owner
-
-The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.
-
-The Product Owner is also accountable for effective Product Backlog management, which includes:
-
-- Developing and explicitly communicating the Product Goal;
-- Creating and clearly communicating Product Backlog items;
-- Ordering Product Backlog items; and,
-- Ensuring that the Product Backlog is transparent, visible and understood.
-
-The Product Owner may do the above work or may delegate the responsibility to others. Regardless, the Product Owner remains accountable.
-
-For Product Owners to succeed, the entire organization must respect their decisions. These decisions are visible in the content and ordering of the Product Backlog, and through the inspectable Increment at the Sprint Review.
-
-The Product Owner is one person, not a committee. The Product Owner may represent the needs of many stakeholders in the Product Backlog. Those wanting to change the Product Backlog can do so by trying to convince the Product Owner.
-
-### Scrum Master
-
-The Scrum Master is accountable for establishing Scrum as defined in the Scrum Guide. They do this by helping everyone understand Scrum theory and practice, both within the Scrum Team and the organization.
-
-The Scrum Master is accountable for the Scrum Team’s effectiveness. They do this by enabling the Scrum Team to improve its practices, within the Scrum framework.
-
-Scrum Masters are true leaders who serve the Scrum Team and the larger organization.
-
-The Scrum Master serves the Scrum Team in several ways, including:
-
-- Coaching the team members in self-management and cross-functionality;
-- Helping the Scrum Team focus on creating high-value Increments that meet the Definition of Done;
-- Causing the removal of impediments to the Scrum Team’s progress; and,
-- Ensuring that all Scrum events take place and are positive, productive, and kept within the timebox.
-
+Scrum Master Service to the Product Owner
 The Scrum Master serves the Product Owner in several ways, including:
-
-- Helping find techniques for effective Product Goal definition and Product Backlog management;
+- Ensuring that goals, scope, and product domain are understood by everyone on the Scrum
+Team as well as possible;
+- Finding techniques for effective Product Backlog management;
 - Helping the Scrum Team understand the need for clear and concise Product Backlog items;
-- Helping establish empirical product planning for a complex environment; and,
-- Facilitating stakeholder collaboration as requested or needed.
-
+- Understanding product planning in an empirical environment;
+- Ensuring the Product Owner knows how to arrange the Product Backlog to maximize value;
+- Understanding and practicing agility; and,
+- Facilitating Scrum events as requested or needed.
+Scrum Master Service to the Development Team
+The Scrum Master serves the Development Team in several ways, including:
+- Coaching the Development Team in self-organization and cross-functionality;
+- Helping the Development Team to create high-value products;
+- Removing impediments to the Development Team’s progress;
+- Facilitating Scrum events as requested or needed; and,
+- Coaching the Development Team in organizational environments in which Scrum is not yet
+fully adopted and understood.
+Scrum Master Service to the Organization
 The Scrum Master serves the organization in several ways, including:
-
-- Leading, training, and coaching the organization in its Scrum adoption;
-- Planning and advising Scrum implementations within the organization;
-- Helping employees and stakeholders understand and enact an empirical approach for complex work; and,
-- Removing barriers between stakeholders and Scrum Teams.
-
-## Scrum Events
-
-The Sprint is a container for all other events. Each event in Scrum is a formal opportunity to inspect and adapt Scrum artifacts. These events are specifically designed to enable the transparency required. Failure to operate any events as prescribed results in lost opportunities to inspect and adapt. Events are used in Scrum to create regularity and to minimize the need for meetings not defined in Scrum.
-
-Optimally, all events are held at the same time and place to reduce complexity.
-
-### The Sprint
-
-Sprints are the heartbeat of Scrum, where ideas are turned into value.
-
-They are fixed length events of one month or less to create consistency. A new Sprint starts immediately after the conclusion of the previous Sprint.
-
-All the work necessary to achieve the Product Goal, including Sprint Planning, Daily Scrums, Sprint Review, and Sprint Retrospective, happen within Sprints.
-
+- Leading and coaching the organization in its Scrum adoption;
+- Planning Scrum implementations within the organization;
+- Helping employees and stakeholders understand and enact Scrum and empirical product
+development;
+- Causing change that increases the productivity of the Scrum Team; and,
+- Working with other Scrum Masters to increase the effectiveness of the application of Scrum
+in the organization.
+Scrum Events
+Prescribed events are used in Scrum to create regularity and to minimize the need for meetings
+not defined in Scrum. All events are time-boxed events, such that every event has a maximum
+duration. Once a Sprint begins, its duration is fixed and cannot be shortened or lengthened. The
+remaining events may end whenever the purpose of the event is achieved, ensuring an
+appropriate amount of time is spent without allowing waste in the process.
+Other than the Sprint itself, which is a container for all other events, each event in Scrum is a
+formal opportunity to inspect and adapt something. These events are specifically designed to
+enable critical transparency and inspection. Failure to include any of these events results in
+reduced transparency and is a lost opportunity to inspect and adapt.
+The Sprint
+The heart of Scrum is a Sprint, a time-box of one month or less during which a “Done”, useable,
+and potentially releasable product Increment is created. Sprints have consistent durations
+throughout a development effort. A new Sprint starts immediately after the conclusion of the
+previous Sprint.
+Sprints contain and consist of the Sprint Planning, Daily Scrums, the development work, the
+Sprint Review, and the Sprint Retrospective.
 During the Sprint:
-
 - No changes are made that would endanger the Sprint Goal;
-- Quality does not decrease;
-- The Product Backlog is refined as needed; and,
-- Scope may be clarified and renegotiated with the Product Owner as more is learned.
-
-Sprints enable predictability by ensuring inspection and adaptation of progress toward a Product Goal at least every calendar month. When a Sprint’s horizon is too long the Sprint Goal may become invalid, complexity may rise, and risk may increase. Shorter Sprints can be employed to generate more learning cycles and limit risk of cost and effort to a smaller time frame. Each Sprint may be considered a short project.
-
-Various practices exist to forecast progress, like burn-downs, burn-ups, or cumulative flows. While proven useful, these do not replace the importance of empiricism. In complex environments, what will happen is unknown. Only what has already happened may be used for forward-looking decision making.
-
-A Sprint could be cancelled if the Sprint Goal becomes obsolete. Only the Product Owner has the authority to cancel the Sprint.
-
-### Sprint Planning
-
-Sprint Planning initiates the Sprint by laying out the work to be performed for the Sprint. This resulting plan is created by the collaborative work of the entire Scrum Team.
-
-The Product Owner ensures that attendees are prepared to discuss the most important Product Backlog items and how they map to the Product Goal. The Scrum Team may also invite other people to attend Sprint Planning to provide advice.
-
-Sprint Planning addresses the following topics:
-
-#### Topic One: Why is this Sprint valuable?
-
-The Product Owner proposes how the product could increase its value and utility in the current Sprint. The whole Scrum Team then collaborates to define a Sprint Goal that communicates why the Sprint is valuable to stakeholders. The Sprint Goal must be finalized prior to the end of Sprint Planning.
-
-#### Topic Two: What can be Done this Sprint?
-
-Through discussion with the Product Owner, the Developers select items from the Product Backlog to include in the current Sprint. The Scrum Team may refine these items during this process, which increases understanding and confidence.
-
-Selecting how much can be completed within a Sprint may be challenging. However, the more the Developers know about their past performance, their upcoming capacity, and their Definition of Done, the more confident they will be in their Sprint forecasts.
-
-#### Topic Three: How will the chosen work get done?
-
-For each selected Product Backlog item, the Developers plan the work necessary to create an Increment that meets the Definition of Done. This is often done by decomposing Product Backlog items into smaller work items of one day or less. How this is done is at the sole discretion of the Developers. No one else tells them how to turn Product Backlog items into Increments of value.
-
-The Sprint Goal, the Product Backlog items selected for the Sprint, plus the plan for delivering them are together referred to as the Sprint Backlog.
-
-Sprint Planning is timeboxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
-
-### Daily Scrum
-
-The purpose of the Daily Scrum is to inspect progress toward the Sprint Goal and adapt the Sprint Backlog as necessary, adjusting the upcoming planned work.
-
-The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is held at the same time and place every working day of the Sprint. If the Product Owner or Scrum Master are actively working on items in the Sprint Backlog, they participate as Developers.
-
-The Developers can select whatever structure and techniques they want, as long as their Daily Scrum focuses on progress toward the Sprint Goal and produces an actionable plan for the next day of work. This creates focus and improves self-management.
-
-Daily Scrums improve communications, identify impediments, promote quick decision-making, and consequently eliminate the need for other meetings.
-
-The Daily Scrum is not the only time Developers are allowed to adjust their plan. They often meet throughout the day for more detailed discussions about adapting or re-planning the rest of the Sprint’s work.
-
-### Sprint Review
-
-The purpose of the Sprint Review is to inspect the outcome of the Sprint and determine future adaptations. The Scrum Team presents the results of their work to key stakeholders and progress toward the Product Goal is discussed.
-
-During the event, the Scrum Team and stakeholders review what was accomplished in the Sprint and what has changed in their environment. Based on this information, attendees collaborate on what to do next. The Product Backlog may also be adjusted to meet new opportunities. The Sprint Review is a working session and the Scrum Team should avoid limiting it to a presentation.
-
-The Sprint Review is the second to last event of the Sprint and is timeboxed to a maximum of four hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
-
-### Sprint Retrospective
-
-The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness.
-
-The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes, tools, and their Definition of Done. Inspected elements often vary with the domain of work. Assumptions that led them astray are identified and their origins explored. The Scrum Team discusses what went well during the Sprint, what problems it encountered, and how those problems were (or were not) solved.
-
-The Scrum Team identifies the most helpful changes to improve its effectiveness. The most impactful improvements are addressed as soon as possible. They may even be added to the Sprint Backlog for the next Sprint.
-
-The Sprint Retrospective concludes the Sprint. It is timeboxed to a maximum of three hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
-
-## Scrum Artifacts
-
-Scrum’s artifacts represent work or value. They are designed to maximize transparency of key information. Thus, everyone inspecting them has the same basis for adaptation.
-
-Each artifact contains a commitment to ensure it provides information that enhances transparency and focus against which progress can be measured:
-
-For the Product Backlog it is the Product Goal.
-
-For the Sprint Backlog it is the Sprint Goal.
-
-For the Increment it is the Definition of Done.
-
-These commitments exist to reinforce empiricism and the Scrum values for the Scrum Team and their stakeholders.
-
-### Product Backlog
-
-The Product Backlog is an emergent, ordered list of what is needed to improve the product. It is the single source of work undertaken by the Scrum Team.
-
-Product Backlog items that can be Done by the Scrum Team within one Sprint are deemed ready for selection in a Sprint Planning event. They usually acquire this degree of transparency after refining activities. Product Backlog refinement is the act of breaking down and further defining Product Backlog items into smaller more precise items. This is an ongoing activity to add details, such as a description, order, and size. Attributes often vary with the domain of work.
-
-The Developers who will be doing the work are responsible for the sizing. The Product Owner may influence the Developers by helping them understand and select trade-offs.
-
-#### Commitment: Product Goal
-
-The Product Goal describes a future state of the product which can serve as a target for the Scrum Team to plan against. The Product Goal is in the Product Backlog. The rest of the Product Backlog emerges to define “what” will fulfill the Product Goal.
-
-> A product is a vehicle to deliver value. It has a clear boundary, known stakeholders, well-defined users or customers. A product could be a service, a physical product, or something more abstract.
-
-The Product Goal is the long-term objective for the Scrum Team. They must fulfill (or abandon) one objective before taking on the next.
-
-### Sprint Backlog
-
-The Sprint Backlog is composed of the Sprint Goal (why), the set of Product Backlog items selected for the Sprint (what), as well as an actionable plan for delivering the Increment (how).
-
-The Sprint Backlog is a plan by and for the Developers. It is a highly visible, real-time picture of the work that the Developers plan to accomplish during the Sprint in order to achieve the Sprint Goal. Consequently, the Sprint Backlog is updated throughout the Sprint as more is learned. It should have enough detail that they can inspect their progress in the Daily Scrum.
-
-#### Commitment: Sprint Goal
-
-The Sprint Goal is the single objective for the Sprint. Although the Sprint Goal is a commitment by the Developers, it provides flexibility in terms of the exact work needed to achieve it. The Sprint Goal also creates coherence and focus, encouraging the Scrum Team to work together rather than on separate initiatives.
-
-The Sprint Goal is created during the Sprint Planning event and then added to the Sprint Backlog. As the Developers work during the Sprint, they keep the Sprint Goal in mind. If the work turns out to be different than they expected, they collaborate with the Product Owner to negotiate the scope of the Sprint Backlog within the Sprint without affecting the Sprint Goal.
-
-### Increment
-
-An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all prior Increments and thoroughly verified, ensuring that all Increments work together. In order to provide value, the Increment must be usable.
-
-Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the Sprint Review thus supporting empiricism. However, an Increment may be delivered to stakeholders prior to the end of the Sprint. The Sprint Review should never be considered a gate to releasing value.
-
-Work cannot be considered part of an Increment unless it meets the Definition of Done.
-
-#### Commitment: Definition of Done
-
-The Definition of Done is a formal description of the state of the Increment when it meets the quality measures required for the product.
-
-The moment a Product Backlog item meets the Definition of Done, an Increment is born.
-
-The Definition of Done creates transparency by providing everyone a shared understanding of what work was completed as part of the Increment. If a Product Backlog item does not meet the Definition of Done, it cannot be released or even presented at the Sprint Review. Instead, it returns to the Product Backlog for future consideration.
-
-If the Definition of Done for an increment is part of the standards of the organization, all Scrum Teams must follow it as a minimum. If it is not an organizational standard, the Scrum Team must create a Definition of Done appropriate for the product.
-
-The Developers are required to conform to the Definition of Done. If there are multiple Scrum Teams working together on a product, they must mutually define and comply with the same Definition of Done.
-
-## End Note
-
-Scrum is free and offered in this Guide. The Scrum framework, as outlined herein, is immutable. While implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists only in its entirety and functions well as a container for other techniques, methodologies, and practices.
-
-### Acknowledgements
-
-#### People
-
-Of the thousands of people who have contributed to Scrum, we should single out those who were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them worked together. Many others contributed in the ensuing years and without their help Scrum would not be refined as it is today.
-
-#### Scrum Guide History
-
-Ken Schwaber and Jeff Sutherland first co-presented Scrum at the OOPSLA Conference in 1995. It essentially documented the learning that Ken and Jeff gained over the previous few years and made public the first formal definition of Scrum.
-
-The Scrum Guide documents Scrum as developed, evolved, and sustained for 30-plus years by Jeff Sutherland and Ken Schwaber. Other sources provide patterns, processes, and insights that complement the Scrum framework. These may increase productivity, value, creativity, and satisfaction with the results.
-
-The complete history of Scrum is described elsewhere. To honor the first places where it was tried and proven, we recognize Individual Inc., Newspage, Fidelity Investments, and IDX (now GE Medical).
-
-© 2020 Ken Schwaber and Jeff Sutherland This publication is offered for license under the Attribution Share-Alike license of Creative Commons, accessible at https://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary form at https://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide, you acknowledge and agree that you have read and agree to be bound by the terms of the Attribution Share-Alike license of Creative Commons.
+- Quality goals do not decrease; and,
+- Scope may be clarified and re-negotiated between the Product Owner and Development
+Team as more is learned.
+Each Sprint may be considered a project with no more than a one-month horizon. Like projects,
+Sprints are used to accomplish something. Each Sprint has a goal of what is to be built, a design
+and flexible plan that will guide building it, the work, and the resultant product increment.
+Sprints are limited to one calendar month. When a Sprint’s horizon is too long the definition of
+what is being built may change, complexity may rise, and risk may increase. Sprints enable
+predictability by ensuring inspection and adaptation of progress toward a Sprint Goal at least
+every calendar month. Sprints also limit risk to one calendar month of cost.
+Cancelling a Sprint
+A Sprint can be cancelled before the Sprint time-box is over. Only the Product Owner has the
+authority to cancel the Sprint, although he or she may do so under influence from the
+stakeholders, the Development Team, or the Scrum Master.
+A Sprint would be cancelled if the Sprint Goal becomes obsolete. This might occur if the
+company changes direction or if market or technology conditions change. In general, a Sprint
+should be cancelled if it no longer makes sense given the circumstances. But, due to the short
+duration of Sprints, cancellation rarely makes sense.
+When a Sprint is cancelled, any completed and “Done” Product Backlog items are reviewed. If
+part of the work is potentially releasable, the Product Owner typically accepts it. All incomplete
+Product Backlog Items are re-estimated and put back on the Product Backlog. The work done on
+them depreciates quickly and must be frequently re-estimated.
+Sprint cancellations consume resources, since everyone regroups in another Sprint 
+Planning to start another Sprint. Sprint cancellations are often traumatic to the Scrum Team,
+and are very uncommon.
+
+Sprint Planning
+The work to be performed in the Sprint is planned at the Sprint Planning. This plan is created by
+the collaborative work of the entire Scrum Team.
+Sprint Planning is time-boxed to a maximum of eight hours for a one-month Sprint. For shorter
+Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and
+that attendants understand its purpose. The Scrum Master teaches the Scrum Team to keep it
+within the time-box.
+
+Sprint Planning answers the following:
+- What can be delivered in the Increment resulting from the upcoming Sprint?
+- How will the work needed to deliver the Increment be achieved?
+
+Topic One: What can be done this Sprint?
+The Development Team works to forecast the functionality that will be developed during the
+Sprint. The Product Owner discusses the objective that the Sprint should achieve and the
+Product Backlog items that, if completed in the Sprint, would achieve the Sprint Goal. The entire
+Scrum Team collaborates on understanding the work of the Sprint.
+The input to this meeting is the Product Backlog, the latest product Increment, projected
+capacity of the Development Team during the Sprint, and past performance of the Development
+Team. The number of items selected from the Product Backlog for the Sprint is solely up to the
+Development Team. Only the Development Team can assess what it can accomplish over the
+upcoming Sprint.
+During Sprint Planning the Scrum Team also crafts a Sprint Goal. The Sprint Goal is an objective
+that will be met within the 
+Sprint through the implementation of the Product Backlog, and it provides guidance to the 
+Development Team on why it is building the Increment.
+
+Topic Two: How will the chosen work get done?
+Having set the Sprint Goal and selected the Product Backlog items for the Sprint, the
+Development Team decides how it will build this functionality into a “Done” product Increment
+during the Sprint. The Product Backlog items selected for this Sprint plus the plan for delivering
+them is called the Sprint Backlog.
+The Development Team usually starts by designing the system and the work needed to convert
+the Product Backlog into a working product Increment. Work may be of varying size, or
+estimated effort. However, enough work is planned during Sprint Planning for the Development
+Team to forecast what it believes it can do in the upcoming Sprint. Work planned for the first
+days of the Sprint by the Development Team is decomposed by the end of this meeting, often to
+units of one day or less. The Development Team self-organizes to undertake the work in the
+Sprint Backlog, both during Sprint Planning and as needed throughout the Sprint.
+The Product Owner can help to clarify the selected Product Backlog items and make trade-offs.
+If the Development Team determines it has too much or too little work, it may renegotiate the
+selected Product Backlog items with the Product Owner. The Development Team may also invite
+other people to attend to provide technical or domain advice.
+By the end of the Sprint Planning, the Development Team should be able to explain to the
+Product Owner and Scrum Master how it intends to work as a self-organizing team to
+accomplish the Sprint Goal and create the anticipated Increment.
+
+Sprint Goal
+The Sprint Goal is an objective set for the Sprint that can be met through the implementation of
+Product Backlog. It provides guidance to the Development Team on why it is building the
+Increment. It is created during the Sprint Planning meeting. The Sprint Goal gives the
+Development Team some flexibility regarding the functionality implemented within the Sprint.
+The selected Product Backlog items deliver one coherent function, which can be the Sprint Goal.
+The Sprint Goal can be any other coherence that causes the Development Team to work
+together rather than on separate initiatives.
+As the Development Team works, it keeps the Sprint Goal in mind. In order to satisfy the Sprint
+Goal, it implements functionality and technology. If the work turns out to be different than 
+the Development Team expected, they collaborate with the Product Owner to negotiate the 
+scope of Sprint Backlog within the Sprint. 
+
+Daily Scrum
+The Daily Scrum is a 15-minute time-boxed event for the Development Team. The Daily Scrum is
+held every day of the Sprint. At it, the Development Team plans work for the next 24 hours. This
+optimizes team collaboration and performance by inspecting the work since the last Daily Scrum
+and forecasting upcoming Sprint work. The Daily Scrum is held at the same time and place each
+day to reduce complexity.
+The Development Team uses the Daily Scrum to inspect progress toward the Sprint Goal and to
+inspect how progress is trending toward completing the work in the Sprint Backlog. The Daily
+Scrum optimizes the probability that the Development Team will meet the Sprint Goal. Every
+day, the Development Team should understand how it intends to work together as a selforganizing
+team to accomplish the Sprint Goal and create the anticipated Increment by the end
+of the Sprint.
+The structure of the meeting is set by the Development Team and can be conducted in different
+ways if it focuses on progress toward the Sprint Goal. Some Development Teams will use
+questions, some will be more discussion based. Here is an example of what might be used:
+- What did I do yesterday that helped the Development Team meet the Sprint Goal?
+- What will I do today to help the Development Team meet the Sprint Goal?
+- Do I see any impediment that prevents me or the Development Team from meeting the
+Sprint Goal?
+The Development Team or team members often meet immediately after the Daily Scrum for
+detailed discussions, or to adapt, or replan, the rest of the Sprint’s work.
+The Scrum Master ensures that the Development Team has the meeting, but the Development
+Team is responsible for conducting the Daily Scrum. The Scrum Master teaches the
+Development Team to keep the Daily Scrum within the 15-minute time-box.
+The Daily Scrum is an internal meeting for the Development Team. If others are present, the
+Scrum Master ensures that they do not disrupt the meeting.
+Daily Scrums improve communications, eliminate other meetings, identify impediments to
+development for removal, highlight and promote quick decision-making, and improve the
+Development Team’s level of knowledge. This is a key inspect and adapt meeting.
+Sprint Review
+A Sprint Review is held at the end of the Sprint to inspect the Increment and adapt the Product
+Backlog if needed. During the Sprint Review, the Scrum Team and stakeholders collaborate
+about what was done in the Sprint. Based on that and any changes to the Product Backlog
+during the Sprint, attendees collaborate on the next things that could be done to optimize value.
+This is an informal meeting, not a status meeting, and the presentation of the Increment is
+intended to elicit feedback and foster collaboration.
+This is at most a four-hour meeting for one-month Sprints. For shorter Sprints, the event is
+usually shorter. The Scrum Master ensures that the event takes place and that attendees
+understand its purpose. The Scrum Master teaches everyone involved to keep it within the timebox.
+The Sprint Review includes the following elements:
+- Attendees include the Scrum Team and key stakeholders invited by the Product Owner;
+- The Product Owner explains what Product Backlog items have been “Done” and what has
+not been “Done”;
+- The Development Team discusses what went well during the Sprint, what problems it ran
+into, and how those problems were solved;
+- The Development Team demonstrates the work that it has “Done” and answers questions
+about the Increment;
+- The Product Owner discusses the Product Backlog as it stands. He or she projects likely
+target and delivery dates based on progress to date (if needed);
+- The entire group collaborates on what to do next, so that the Sprint Review provides
+valuable input to subsequent Sprint Planning;
+- Review of how the marketplace or potential use of the product might have changed what is
+the most valuable thing to do next; and,
+- Review of the timeline, budget, potential capabilities, and marketplace for the next
+anticipated releases of functionality or capability of the product.
+The result of the Sprint Review is a revised Product Backlog that defines the probable Product
+Backlog items for the next Sprint. The Product Backlog may also be adjusted overall to meet new
+opportunities.
+
+Sprint Retrospective
+The Sprint Retrospective is an opportunity for the Scrum Team to inspect itself and create a plan
+for improvements to be enacted during the next Sprint.
+The Sprint Retrospective occurs after the Sprint Review and prior to the next Sprint Planning.
+This is at most a three-hour meeting for one-month Sprints. For shorter Sprints, the event is
+usually shorter. The Scrum Master ensures that the event takes place and that attendants
+understand its purpose.
+The Scrum Master ensures that the meeting is positive and productive. The Scrum Master
+teaches all to keep it within the time-box. The Scrum Master participates as a peer team
+member in the meeting from the accountability over the Scrum process.
+The purpose of the Sprint Retrospective is to:
+- Inspect how the last Sprint went with regards to people, relationships, process, and tools;
+- Identify and order the major items that went well and potential improvements; and,
+- Create a plan for implementing improvements to the way the Scrum Team does its work.
+The Scrum Master encourages the Scrum Team to improve, within the Scrum process
+framework, its development process and practices to make it more effective and enjoyable for
+the next Sprint. During each Sprint Retrospective, the Scrum Team plans ways to increase
+product quality by improving work processes or adapting the definition of “Done”, if appropriate
+and not in conflict with product or organizational standards.
+By the end of the Sprint Retrospective, the Scrum Team should have identified improvements
+that it will implement in the next Sprint. Implementing these improvements in the next Sprint is
+the adaptation to the inspection of the Scrum Team itself. Although improvements may be
+implemented at any time, the Sprint Retrospective provides a formal opportunity to focus on
+inspection and adaptation.
+
+Scrum Artifacts
+Scrum’s artifacts represent work or value to provide transparency and opportunities for
+inspection and adaptation. Artifacts defined by Scrum are specifically designed to maximize
+transparency of key information so that everybody has the same understanding of the artifact.
+
+Product Backlog
+The Product Backlog is an ordered list of everything that is known to be needed in the product.
+It is the single source of requirements for any changes to be made to the product. The Product
+Owner is responsible for the Product Backlog, including its content, availability, and ordering.
+A Product Backlog is never complete. The earliest development of it lays out the initially known
+and best-understood requirements. The Product Backlog evolves as the product and the
+environment in which it will be used evolves. The Product Backlog is dynamic; it constantly
+changes to identify what the product needs to be appropriate, competitive, and useful. If a
+product exists, its Product Backlog also exists.
+The Product Backlog lists all features, functions, requirements, enhancements, and fixes that
+constitute the changes to be made to the product in future releases. Product Backlog items have
+the attributes of a description, order, estimate, and value.
+Product Backlog items often include test descriptions that will prove its completeness when “Done.”
+As a product is used and gains value, and the marketplace provides feedback, the Product
+Backlog becomes a larger and more exhaustive list. Requirements never stop changing, so a
+Product Backlog is a living artifact. Changes in business requirements, market conditions, or
+technology may cause changes in the Product Backlog.
+Multiple Scrum Teams often work together on the same product. One Product Backlog is used
+to describe the upcoming work on the product. A Product Backlog attribute that groups items
+may then be employed.
+
+Product Backlog refinement is the act of adding detail, estimates, and order to items in the
+Product Backlog. This is an ongoing process in which the Product Owner and the Development
+Team collaborate on the details of Product Backlog items. During Product Backlog refinement,
+items are reviewed and revised. The Scrum Team decides how and when refinement is done.
+Refinement usually consumes no more than 10% of the capacity of the Development Team.
+However, Product Backlog items can be updated at any time by the Product Owner or at the
+Product Owner’s discretion.
+Higher ordered Product Backlog items are usually clearer and more detailed than lower ordered
+ones. More precise estimates are made based on the greater clarity and increased detail; the
+lower the order, the less detail. Product Backlog items that will occupy the Development Team
+for the upcoming Sprint are refined so that any one item can reasonably be “Done” within the
+Sprint time-box. Product Backlog items that can be “Done” by the Development Team within
+one Sprint are deemed “Ready” for selection in a Sprint Planning. Product Backlog items usually
+acquire this degree of transparency through the above described refining activities.
+The Development Team is responsible for all estimates. The Product Owner may influence the
+Development Team by helping it understand and select trade-offs, but the people who will
+perform the work make the final estimate.
+Monitoring Progress Toward Goals
+At any point in time, the total work remaining to reach a goal can be summed. The Product
+Owner tracks this total work remaining at least every Sprint Review. The Product Owner
+compares this amount with work remaining at previous Sprint Reviews to assess progress
+toward completing projected work by the desired time for the goal. This information is made
+transparent to all stakeholders.
+Various projective practices upon trending have been used to forecast progress, like burndowns, burn-ups, or cumulative flows. These have proven useful. However, these do not replace
+the importance of empiricism. In complex environments, what will happen is unknown. Only
+what has already happened may be used for forward-looking decision-making.
+
+Sprint Backlog
+The Sprint Backlog is the set of Product Backlog items selected for the Sprint, plus a plan for
+delivering the product Increment and realizing the Sprint Goal. The Sprint Backlog is a forecast
+by the Development Team about what functionality will be in the next Increment and the work
+needed to deliver that functionality into a “Done” Increment.
+The Sprint Backlog makes visible all the work that the Development Team identifies as necessary
+to meet the Sprint Goal. 
+To ensure continuous improvement, it includes at least one high
+priority process improvement identified in the previous Retrospective meeting.
+The Sprint Backlog is a plan with enough detail that changes in progress can be understood in
+the Daily Scrum. The Development Team modifies the Sprint Backlog throughout the Sprint, and
+the Sprint Backlog emerges during the Sprint. This emergence occurs as the Development Team
+works through the plan and learns more about the work needed to achieve the Sprint Goal.
+As new work is required, the Development Team adds it to the Sprint Backlog. As work is
+performed or completed, the estimated remaining work is updated. When elements of the plan
+are deemed unnecessary, they are removed. Only the Development Team can change its Sprint
+Backlog during a Sprint. The Sprint Backlog is a highly visible, real-time picture of the work that
+the Development Team plans to accomplish during the Sprint, and it belongs solely to the
+Development Team.
+Monitoring Sprint Progress
+At any point in time in a Sprint, the total work remaining in the Sprint Backlog can be summed.
+The Development Team tracks this total work remaining at least for every Daily Scrum to project
+the likelihood of achieving the Sprint Goal. By tracking the remaining work throughout the
+Sprint, the Development Team can manage its progress.
+Increment
+The Increment is the sum of all the Product Backlog items completed during a Sprint and the
+value of the increments of all previous Sprints. At the end of a Sprint, the new Increment must
+be “Done,” which means it must be in useable condition and meet the Scrum Team’s definition
+of “Done.” An increment is a body of inspectable, done work that supports empiricism at the
+end of the Sprint. The increment is a step toward a vision or goal. The increment must be in
+useable condition regardless of whether the Product Owner decides to release it.
+Artifact Transparency
+Scrum relies on transparency. Decisions to optimize value and control risk are made based on
+the perceived state of the artifacts. To the extent that transparency is complete, these decisions
+have a sound basis. To the extent that the artifacts are incompletely transparent, these
+decisions can be flawed, value may diminish and risk may increase.
+The Scrum Master must work with the Product Owner, Development Team, and other involved
+parties to understand if the artifacts are completely transparent. There are practices for coping
+with incomplete transparency; the Scrum Master must help everyone apply the most
+appropriate practices in the absence of complete transparency. A Scrum Master can detect
+incomplete transparency by inspecting the artifacts, sensing patterns, listening closely to what is
+being said, and detecting differences between expected and real results.
+The Scrum Master’s job is to work with the Scrum Team and the organization to increase the
+transparency of the artifacts. This work usually involves learning, convincing, and change.
+Transparency doesn’t occur overnight, but is a path.
+Definition of “Done”
+When a Product Backlog item or an Increment is described as “Done”, everyone must
+understand what “Done” means. Although this may vary significantly per Scrum Team, members
+must have a shared understanding of what it means for work to be complete, to ensure
+transparency. This is the definition of “Done” for the Scrum Team and is used to assess when
+work is complete on the product Increment.
+The same definition guides the Development Team in knowing how many Product Backlog items
+it can select during a Sprint Planning. The purpose of each Sprint is to deliver Increments of
+potentially releasable functionality that adhere to the Scrum Team’s current definition of
+“Done.”
+Development Teams deliver an Increment of product functionality every Sprint. This Increment
+is useable, so a Product Owner may choose to immediately release it. If the definition of "Done"
+for an increment is part of the conventions, standards or guidelines of the development
+organization, all Scrum Teams must follow it as a minimum. If "Done" for an increment is not a 
+convention of the development organization, the
+Development Team of the Scrum Team must define a definition of “Done” appropriate for the
+product. If there are multiple Scrum Teams working on the system or product release, the
+Development Teams on all the Scrum Teams must mutually define the definition of “Done.”
+Each Increment is additive to all prior Increments and thoroughly tested, ensuring that all
+Increments work together.
+As Scrum Teams mature, it is expected that their definitions of “Done” will expand to include
+more stringent criteria for higher quality. New definitions, as used, may uncover work to be
+done in previously “Done” increments. Any one product or system should have a definition of
+“Done” that is a standard for any work done on it.
+
+End Note
+Scrum is free and offered in this Guide. Scrum’s roles, events, artifacts, and rules are immutable
+and although implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists
+only in its entirety and functions well as a container for other techniques, methodologies, and
+practices.
+Acknowledgements
+People
+Of the thousands of people who have contributed to Scrum, we should single out those who
+were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John
+Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them
+worked together. Many others contributed in the ensuing years and without their help Scrum
+would not be refined as it is today.
+History
+Ken Schwaber and Jeff Sutherland worked on Scrum until 1995, when they co-presented Scrum
+at the OOPSLA Conference in 1995. This presentation essentially documented the learning that
+Ken and Jeff gained over the previous few years, and made public the first formal definition of
+Scrum.
+The history of Scrum is described elsewhere. To honor the first places where it was tried and
+refined, we recognize Individual, Inc., Newspage, Fidelity Investments, and IDX (now GE
+Medical).
+The Scrum Guide documents Scrum as developed, evolved, and sustained for 20-plus years by
+Jeff Sutherland and Ken Schwaber. Other sources provide you with patterns, processes, and
+insights that complement the Scrum framework. These may increase productivity, value,
+creativity, and satisfaction with the results.

--- a/scrum guide
+++ b/scrum guide
@@ -1,536 +1,300 @@
-﻿The Scrum Guide
-The Definitive Guide to Scrum:
-The Rules of the Game
+﻿# The Scrum Guide
 
-November 2017
+Ken Schwaber & Jeff Sutherland
+The Definitive Guide to Scrum: The Rules of the Game
+November 2020
 
-Developed and sustained by Scrum creators: Ken Schwaber and Jeff Sutherland
+## Purpose of the Scrum Guide
 
-Purpose of the Scrum Guide
-Scrum is a framework for developing, delivering, and sustaining complex products. This Guide contains the
-definition of Scrum. This definition consists of Scrum’s roles, events, artifacts, and the rules that 
-bind them together. Ken Schwaber and Jeff Sutherland developed Scrum; the Scrum Guide is 
-written and provided by them. Together, they stand behind the Scrum Guide.
-Definition of Scrum
-Scrum (n): A framework within which people can address complex adaptive problems, while
-productively and creatively delivering products of the highest possible value.
-Scrum is:
-- Lightweight
-- Simple to understand
-- Difficult to master
-Scrum is a process framework that has been used to manage work on complex products 
-since the early 1990s. Scrum is not a process, technique, or definitive method. Rather, it is a
-framework within which you can employ various processes and techniques. Scrum makes clear
-the relative efficacy of your product management and work techniques so that you can
-continuously improve the product, the team, and the working environment.
-The Scrum framework consists of Scrum Teams and their associated roles, events, artifacts, and
-rules. Each component within the framework serves a specific purpose and is essential to
-Scrum’s success and usage.
-The rules of Scrum bind together the roles, events, and artifacts, governing the relationships and
-interaction between them. The rules of Scrum are described throughout the body of this
-document.
-Specific tactics for using the Scrum framework vary and are described elsewhere.
+We developed Scrum in the early 1990s. We wrote the first version of the Scrum Guide in 2010 to help people worldwide understand Scrum. We have evolved the Guide since then through small, functional updates. Together, we stand behind it.
 
-Uses of Scrum
-Scrum was initially developed for managing and developing products. Starting in the early
-1990s, Scrum has been used extensively, worldwide, to:
-1. Research and identify viable markets, technologies, and product capabilities;
-2. Develop products and enhancements;
-3. Release products and enhancements, as frequently as many times per day;
-4. Develop and sustain Cloud (online, secure, on-demand) and other operational
-environments for product use; and,
-5. Sustain and renew products.
-Scrum has been used to develop software, hardware, embedded software, networks of
-interacting function, autonomous vehicles, schools, government, marketing, managing the
-operation of organizations and almost everything we use in our daily lives, as individuals and
-societies.
-As technology, market, and environmental complexities and their interactions have rapidly
-increased, Scrum’s utility in dealing with complexity is proven daily.
-Scrum proved especially effective in iterative and incremental knowledge transfer. Scrum is now
-widely used for products, services, and the management of the parent organization.
-The essence of Scrum is a small team of people. The individual team is highly flexible and
-adaptive. These strengths continue operating in single, several, many, and networks of teams
-that develop, release, operate and sustain the work and work products of thousands of people.
-They collaborate and interoperate through sophisticated development architectures and target
-release environments.
-When the words “develop” and “development” are used in the Scrum Guide, they refer to
-complex work, such as those types identified above.
+The Scrum Guide contains the definition of Scrum. Each element of the framework serves a specific purpose that is essential to the overall value and results realized with Scrum. Changing the core design or ideas of Scrum, leaving out elements, or not following the rules of Scrum, covers up problems and limits the benefits of Scrum, potentially even rendering it useless.
 
+We follow the growing use of Scrum within an ever-growing complex world. We are humbled to see Scrum being adopted in many domains holding essentially complex work, beyond software product development where Scrum has its roots. As Scrum’s use spreads, developers, researchers, analysts, scientists, and other specialists do the work. We use the word “developers” in Scrum not to exclude, but to simplify. If you get value from Scrum, consider yourself included.
 
-Scrum Theory
-Scrum is founded on empirical process control theory, or empiricism. Empiricism asserts that
-knowledge comes from experience and making decisions based on what is known. Scrum
-employs an iterative, incremental approach to optimize predictability and control risk.
-Three pillars uphold every implementation of empirical process control: transparency,
-inspection, and adaptation.
+As Scrum is being used, patterns, processes, and insights that fit the Scrum framework as described in this document, may be found, applied and devised. Their description is beyond the purpose of the Scrum Guide because they are context sensitive and differ widely between Scrum uses. Such tactics for using within the Scrum framework vary widely and are described elsewhere.
 
-Transparency
-Significant aspects of the process must be visible to those responsible for the outcome.
-Transparency requires those aspects be defined by a common standard so observers share a
-common understanding of what is being seen.
-For example
-- A common language referring to the process must be shared by all participants; and,
-- Those performing the work and those inspecting the resulting increment must share a
-common definition of “Done”.
-Inspection
-Scrum users must frequently inspect Scrum artifacts and progress toward a Sprint Goal to detect
-undesirable variances. Their inspection should not be so frequent that inspection gets in the way
-of the work. Inspections are most beneficial when diligently performed by skilled inspectors at
-the point of work.
-Adaptation
-If an inspector determines that one or more aspects of a process deviate outside acceptable
-limits, and that the resulting product will be unacceptable, the process or the material being
-processed must be adjusted. An adjustment must be made as soon as possible to minimize
-further deviation.
-Scrum prescribes four formal events for inspection and adaptation, as described in the Scrum
-Events section of this document:
-- Sprint Planning
-- Daily Scrum
-- Sprint Review
-- Sprint Retrospective
-Scrum Values
-When the values of commitment, courage, focus, openness and respect are embodied and lived
-by the Scrum Team, the Scrum pillars of transparency, inspection, and adaptation come to life
-and build trust for everyone. The Scrum Team members learn and explore those values as they
-work with the Scrum roles, events, and artifacts.
-Successful use of Scrum depends on people becoming more proficient in living these five values.
-People personally commit to achieving the goals of the Scrum Team. The Scrum Team members
-have courage to do the right thing and work on tough problems. Everyone focuses on the work
-of the Sprint and the goals of the Scrum Team. The Scrum Team and its stakeholders agree to be
-open about all the work and the challenges with performing the work. Scrum Team members
-respect each other to be capable, independent people.
+## Scrum Definition
 
+Scrum is a lightweight framework that helps people, teams and organizations generate value through adaptive solutions for complex problems.
 
-The Scrum Team
-The Scrum Team consists of a Product Owner, the Development Team, and a Scrum Master.
-Scrum Teams are self-organizing and cross-functional. Self-organizing teams choose how best to
-accomplish their work, rather than being directed by others outside the team. Cross-functional
-teams have all competencies needed to accomplish the work without depending on others not
-part of the team. The team model in Scrum is designed to optimize flexibility, creativity, and
-productivity. The Scrum Team has proven itself to be increasingly effective for all the earlier
-stated uses, and any complex work.
-Scrum Teams deliver products iteratively and incrementally, maximizing opportunities for
-feedback. Incremental deliveries of “Done” product ensure a potentially useful version of
-working product is always available.
-The Product Owner
-The Product Owner is responsible for maximizing the value of the product resulting from work
-of the Development Team. How this is done may vary widely across organizations, Scrum Teams,
-and individuals.
-The Product Owner is the sole person responsible for managing the Product Backlog. Product
-Backlog management includes:
-- Clearly expressing Product Backlog items;
-- Ordering the items in the Product Backlog to best achieve goals and missions;
-- Optimizing the value of the work the Development Team performs;
-- Ensuring that the Product Backlog is visible, transparent, and clear to all, and shows what
-the Scrum Team will work on next; and,
-- Ensuring the Development Team understands items in the Product Backlog to the level
-needed.
-The Product Owner may do the above work, or have the Development Team do it. However, the
-Product Owner remains accountable.
-The Product Owner is one person, not a committee. The Product Owner may represent the
-desires of a committee in the Product Backlog, but those wanting to change a Product Backlog
-item’s priority must address the Product Owner.
-For the Product Owner to succeed, the entire organization must respect his or her decisions. The
-Product Owner’s decisions are visible in the content and ordering of the Product Backlog. No
-one can force the Development Team to work from a different set of requirements.
+In a nutshell, Scrum requires a Scrum Master to foster an environment where:
 
+1. A Product Owner orders the work for a complex problem into a Product Backlog.
+2. The Scrum Team turns a selection of the work into an Increment of value during a Sprint.
+3. The Scrum Team and its stakeholders inspect the results and adjust for the next Sprint.
+4. _Repeat_
 
-The Development Team
-The Development Team consists of professionals who do the work of delivering a potentially
-releasable Increment of “Done” product at the end of each Sprint. A “Done” increment is
-required at the Sprint Review. Only members of the Development Team create the Increment.
-Development Teams are structured and empowered by the organization to organize and
-manage their own work. The resulting synergy optimizes the Development Team’s overall
-efficiency and effectiveness.
-Development Teams have the following characteristics:
-- They are self-organizing. No one (not even the Scrum Master) tells the Development Team
-how to turn Product Backlog into Increments of potentially releasable functionality;
-- Development Teams are cross-functional, with all the skills as a team necessary to create
-a product Increment;
-- Scrum recognizes no titles for Development Team members, regardless of the work being
-performed by the person;
-- Scrum recognizes no sub-teams in the Development Team, regardless of domains that need
-to be addressed like testing, architecture, operations, or business analysis; and,
-- Individual Development Team members may have specialized skills and areas of focus, but
-accountability belongs to the Development Team as a whole.
-Development Team Size
-Optimal Development Team size is small enough to remain nimble and large enough to
-complete significant work within a Sprint. Fewer than three Development Team members
-decrease interaction and results in smaller productivity gains. Smaller Development Teams may
-encounter skill constraints during the Sprint, causing the Development Team to be unable to
-deliver a potentially releasable Increment. Having more than nine members requires too much
-coordination. Large Development Teams generate too much complexity for an empirical process
-to be useful. The Product Owner and Scrum Master roles are not included in this count unless
-they are also executing the work of the Sprint Backlog.
-The Scrum Master
-The Scrum Master is responsible for promoting and supporting Scrum as defined in the Scrum
-Guide. Scrum Masters do this by helping everyone understand Scrum theory, practices, rules,
-and values.
-The Scrum Master is a servant-leader for the Scrum Team. The Scrum Master helps those
-outside the Scrum Team understand which of their interactions with the Scrum Team are helpful
-and which aren’t. The Scrum Master helps everyone change these interactions to maximize the
-value created by the Scrum Team.
+Scrum is simple. Try it as is and determine if its philosophy, theory, and structure help to achieve goals and create value. The Scrum framework is purposefully incomplete, only defining the parts required to implement Scrum theory. Scrum is built upon by the collective intelligence of the people using it. Rather than provide people with detailed instructions, the rules of Scrum guide their relationships and interactions.
 
-Scrum Master Service to the Product Owner
+Various processes, techniques and methods can be employed within the framework. Scrum wraps around existing practices or renders them unnecessary. Scrum makes visible the relative efficacy of current management, environment, and work techniques, so that improvements can be made.
+
+## Scrum Theory
+
+Scrum is founded on empiricism and lean thinking. Empiricism asserts that knowledge comes from experience and making decisions based on what is observed. Lean thinking reduces waste and focuses on the essentials.
+
+Scrum employs an iterative, incremental approach to optimize predictability and to control risk. Scrum engages groups of people who collectively have all the skills and expertise to do the work and share or acquire such skills as needed.
+
+Scrum combines four formal events for inspection and adaptation within a containing event, the Sprint. These events work because they implement the empirical Scrum pillars of transparency, inspection, and adaptation.
+
+### Transparency
+
+The emergent process and work must be visible to those performing the work as well as those receiving the work. With Scrum, important decisions are based on the perceived state of its three formal artifacts. Artifacts that have low transparency can lead to decisions that diminish value and increase risk.
+
+Transparency enables inspection. Inspection without transparency is misleading and wasteful.
+
+### Inspection
+
+The Scrum artifacts and the progress toward agreed goals must be inspected frequently and diligently to detect potentially undesirable variances or problems. To help with inspection, Scrum provides cadence in the form of its five events.
+
+Inspection enables adaptation. Inspection without adaptation is considered pointless. Scrum events are designed to provoke change.
+
+### Adaptation
+
+If any aspects of a process deviate outside acceptable limits or if the resulting product is unacceptable, the process being applied or the materials being produced must be adjusted. The adjustment must be made as soon as possible to minimize further deviation.
+
+Adaptation becomes more difficult when the people involved are not empowered or self-managing. A Scrum Team is expected to adapt the moment it learns anything new through inspection.
+
+## Scrum Values
+
+Successful use of Scrum depends on people becoming more proficient in living five values:
+
+***Commitment, Focus, Openness, Respect, and Courage***
+
+The Scrum Team commits to achieving its goals and to supporting each other. Their primary focus is on the work of the Sprint to make the best possible progress toward these goals. The Scrum Team and its stakeholders are open about the work and the challenges. Scrum Team members respect each other to be capable, independent people, and are respected as such by the people with whom they work. The Scrum Team members have the courage to do the right thing, to work on tough problems.
+
+These values give direction to the Scrum Team with regard to their work, actions, and behavior. The decisions that are made, the steps taken, and the way Scrum is used should reinforce these values, not diminish or undermine them. The Scrum Team members learn and explore the values as they work with the Scrum events and artifacts. When these values are embodied by the Scrum Team and the people they work with, the empirical Scrum pillars of transparency, inspection, and adaptation come to life building trust.
+
+## Scrum Team
+
+The fundamental unit of Scrum is a small team of people, a Scrum Team. The Scrum Team consists of one Scrum Master, one Product Owner, and Developers. Within a Scrum Team, there are no sub-teams or hierarchies. It is a cohesive unit of professionals focused on one objective at a time, the Product Goal.
+
+Scrum Teams are cross-functional, meaning the members have all the skills necessary to create value each Sprint. They are also self-managing, meaning they internally decide who does what, when, and how.
+
+The Scrum Team is small enough to remain nimble and large enough to complete significant work within a Sprint, typically 10 or fewer people. In general, we have found that smaller teams communicate better and are more productive. If Scrum Teams become too large, they should consider reorganizing into multiple cohesive Scrum Teams, each focused on the same product. Therefore, they should share the same Product Goal, Product Backlog, and Product Owner.
+
+The Scrum Team is responsible for all product-related activities from stakeholder collaboration, verification, maintenance, operation, experimentation, research and development, and anything else that might be required. They are structured and empowered by the organization to manage their own work. Working in Sprints at a sustainable pace improves the Scrum Team’s focus and consistency.
+
+The entire Scrum Team is accountable for creating a valuable, useful Increment every Sprint. Scrum defines three specific accountabilities within the Scrum Team: the Developers, the Product Owner, and the Scrum Master.
+
+### Developers
+
+Developers are the people in the Scrum Team that are committed to creating any aspect of a usable Increment each Sprint.
+
+The specific skills needed by the Developers are often broad and will vary with the domain of work. However, the Developers are always accountable for:
+
+- Creating a plan for the Sprint, the Sprint Backlog;
+- Instilling quality by adhering to a Definition of Done;
+- Adapting their plan each day toward the Sprint Goal; and,
+- Holding each other accountable as professionals.
+
+### Product Owner
+
+The Product Owner is accountable for maximizing the value of the product resulting from the work of the Scrum Team. How this is done may vary widely across organizations, Scrum Teams, and individuals.
+
+The Product Owner is also accountable for effective Product Backlog management, which includes:
+
+- Developing and explicitly communicating the Product Goal;
+- Creating and clearly communicating Product Backlog items;
+- Ordering Product Backlog items; and,
+- Ensuring that the Product Backlog is transparent, visible and understood.
+
+The Product Owner may do the above work or may delegate the responsibility to others. Regardless, the Product Owner remains accountable.
+
+For Product Owners to succeed, the entire organization must respect their decisions. These decisions are visible in the content and ordering of the Product Backlog, and through the inspectable Increment at the Sprint Review.
+
+The Product Owner is one person, not a committee. The Product Owner may represent the needs of many stakeholders in the Product Backlog. Those wanting to change the Product Backlog can do so by trying to convince the Product Owner.
+
+### Scrum Master
+
+The Scrum Master is accountable for establishing Scrum as defined in the Scrum Guide. They do this by helping everyone understand Scrum theory and practice, both within the Scrum Team and the organization.
+
+The Scrum Master is accountable for the Scrum Team’s effectiveness. They do this by enabling the Scrum Team to improve its practices, within the Scrum framework.
+
+Scrum Masters are true leaders who serve the Scrum Team and the larger organization.
+
+The Scrum Master serves the Scrum Team in several ways, including:
+
+- Coaching the team members in self-management and cross-functionality;
+- Helping the Scrum Team focus on creating high-value Increments that meet the Definition of Done;
+- Causing the removal of impediments to the Scrum Team’s progress; and,
+- Ensuring that all Scrum events take place and are positive, productive, and kept within the timebox.
+
 The Scrum Master serves the Product Owner in several ways, including:
-- Ensuring that goals, scope, and product domain are understood by everyone on the Scrum
-Team as well as possible;
-- Finding techniques for effective Product Backlog management;
+
+- Helping find techniques for effective Product Goal definition and Product Backlog management;
 - Helping the Scrum Team understand the need for clear and concise Product Backlog items;
-- Understanding product planning in an empirical environment;
-- Ensuring the Product Owner knows how to arrange the Product Backlog to maximize value;
-- Understanding and practicing agility; and,
-- Facilitating Scrum events as requested or needed.
-Scrum Master Service to the Development Team
-The Scrum Master serves the Development Team in several ways, including:
-- Coaching the Development Team in self-organization and cross-functionality;
-- Helping the Development Team to create high-value products;
-- Removing impediments to the Development Team’s progress;
-- Facilitating Scrum events as requested or needed; and,
-- Coaching the Development Team in organizational environments in which Scrum is not yet
-fully adopted and understood.
-Scrum Master Service to the Organization
+- Helping establish empirical product planning for a complex environment; and,
+- Facilitating stakeholder collaboration as requested or needed.
+
 The Scrum Master serves the organization in several ways, including:
-- Leading and coaching the organization in its Scrum adoption;
-- Planning Scrum implementations within the organization;
-- Helping employees and stakeholders understand and enact Scrum and empirical product
-development;
-- Causing change that increases the productivity of the Scrum Team; and,
-- Working with other Scrum Masters to increase the effectiveness of the application of Scrum
-in the organization.
-Scrum Events
-Prescribed events are used in Scrum to create regularity and to minimize the need for meetings
-not defined in Scrum. All events are time-boxed events, such that every event has a maximum
-duration. Once a Sprint begins, its duration is fixed and cannot be shortened or lengthened. The
-remaining events may end whenever the purpose of the event is achieved, ensuring an
-appropriate amount of time is spent without allowing waste in the process.
-Other than the Sprint itself, which is a container for all other events, each event in Scrum is a
-formal opportunity to inspect and adapt something. These events are specifically designed to
-enable critical transparency and inspection. Failure to include any of these events results in
-reduced transparency and is a lost opportunity to inspect and adapt.
-The Sprint
-The heart of Scrum is a Sprint, a time-box of one month or less during which a “Done”, useable,
-and potentially releasable product Increment is created. Sprints have consistent durations
-throughout a development effort. A new Sprint starts immediately after the conclusion of the
-previous Sprint.
-Sprints contain and consist of the Sprint Planning, Daily Scrums, the development work, the
-Sprint Review, and the Sprint Retrospective.
+
+- Leading, training, and coaching the organization in its Scrum adoption;
+- Planning and advising Scrum implementations within the organization;
+- Helping employees and stakeholders understand and enact an empirical approach for complex work; and,
+- Removing barriers between stakeholders and Scrum Teams.
+
+## Scrum Events
+
+The Sprint is a container for all other events. Each event in Scrum is a formal opportunity to inspect and adapt Scrum artifacts. These events are specifically designed to enable the transparency required. Failure to operate any events as prescribed results in lost opportunities to inspect and adapt. Events are used in Scrum to create regularity and to minimize the need for meetings not defined in Scrum.
+
+Optimally, all events are held at the same time and place to reduce complexity.
+
+### The Sprint
+
+Sprints are the heartbeat of Scrum, where ideas are turned into value.
+
+They are fixed length events of one month or less to create consistency. A new Sprint starts immediately after the conclusion of the previous Sprint.
+
+All the work necessary to achieve the Product Goal, including Sprint Planning, Daily Scrums, Sprint Review, and Sprint Retrospective, happen within Sprints.
+
 During the Sprint:
+
 - No changes are made that would endanger the Sprint Goal;
-- Quality goals do not decrease; and,
-- Scope may be clarified and re-negotiated between the Product Owner and Development
-Team as more is learned.
-Each Sprint may be considered a project with no more than a one-month horizon. Like projects,
-Sprints are used to accomplish something. Each Sprint has a goal of what is to be built, a design
-and flexible plan that will guide building it, the work, and the resultant product increment.
-Sprints are limited to one calendar month. When a Sprint’s horizon is too long the definition of
-what is being built may change, complexity may rise, and risk may increase. Sprints enable
-predictability by ensuring inspection and adaptation of progress toward a Sprint Goal at least
-every calendar month. Sprints also limit risk to one calendar month of cost.
-Cancelling a Sprint
-A Sprint can be cancelled before the Sprint time-box is over. Only the Product Owner has the
-authority to cancel the Sprint, although he or she may do so under influence from the
-stakeholders, the Development Team, or the Scrum Master.
-A Sprint would be cancelled if the Sprint Goal becomes obsolete. This might occur if the
-company changes direction or if market or technology conditions change. In general, a Sprint
-should be cancelled if it no longer makes sense given the circumstances. But, due to the short
-duration of Sprints, cancellation rarely makes sense.
-When a Sprint is cancelled, any completed and “Done” Product Backlog items are reviewed. If
-part of the work is potentially releasable, the Product Owner typically accepts it. All incomplete
-Product Backlog Items are re-estimated and put back on the Product Backlog. The work done on
-them depreciates quickly and must be frequently re-estimated.
-Sprint cancellations consume resources, since everyone regroups in another Sprint 
-Planning to start another Sprint. Sprint cancellations are often traumatic to the Scrum Team,
-and are very uncommon.
+- Quality does not decrease;
+- The Product Backlog is refined as needed; and,
+- Scope may be clarified and renegotiated with the Product Owner as more is learned.
 
-Sprint Planning
-The work to be performed in the Sprint is planned at the Sprint Planning. This plan is created by
-the collaborative work of the entire Scrum Team.
-Sprint Planning is time-boxed to a maximum of eight hours for a one-month Sprint. For shorter
-Sprints, the event is usually shorter. The Scrum Master ensures that the event takes place and
-that attendants understand its purpose. The Scrum Master teaches the Scrum Team to keep it
-within the time-box.
+Sprints enable predictability by ensuring inspection and adaptation of progress toward a Product Goal at least every calendar month. When a Sprint’s horizon is too long the Sprint Goal may become invalid, complexity may rise, and risk may increase. Shorter Sprints can be employed to generate more learning cycles and limit risk of cost and effort to a smaller time frame. Each Sprint may be considered a short project.
 
-Sprint Planning answers the following:
-- What can be delivered in the Increment resulting from the upcoming Sprint?
-- How will the work needed to deliver the Increment be achieved?
+Various practices exist to forecast progress, like burn-downs, burn-ups, or cumulative flows. While proven useful, these do not replace the importance of empiricism. In complex environments, what will happen is unknown. Only what has already happened may be used for forward-looking decision making.
 
-Topic One: What can be done this Sprint?
-The Development Team works to forecast the functionality that will be developed during the
-Sprint. The Product Owner discusses the objective that the Sprint should achieve and the
-Product Backlog items that, if completed in the Sprint, would achieve the Sprint Goal. The entire
-Scrum Team collaborates on understanding the work of the Sprint.
-The input to this meeting is the Product Backlog, the latest product Increment, projected
-capacity of the Development Team during the Sprint, and past performance of the Development
-Team. The number of items selected from the Product Backlog for the Sprint is solely up to the
-Development Team. Only the Development Team can assess what it can accomplish over the
-upcoming Sprint.
-During Sprint Planning the Scrum Team also crafts a Sprint Goal. The Sprint Goal is an objective
-that will be met within the 
-Sprint through the implementation of the Product Backlog, and it provides guidance to the 
-Development Team on why it is building the Increment.
+A Sprint could be cancelled if the Sprint Goal becomes obsolete. Only the Product Owner has the authority to cancel the Sprint.
 
-Topic Two: How will the chosen work get done?
-Having set the Sprint Goal and selected the Product Backlog items for the Sprint, the
-Development Team decides how it will build this functionality into a “Done” product Increment
-during the Sprint. The Product Backlog items selected for this Sprint plus the plan for delivering
-them is called the Sprint Backlog.
-The Development Team usually starts by designing the system and the work needed to convert
-the Product Backlog into a working product Increment. Work may be of varying size, or
-estimated effort. However, enough work is planned during Sprint Planning for the Development
-Team to forecast what it believes it can do in the upcoming Sprint. Work planned for the first
-days of the Sprint by the Development Team is decomposed by the end of this meeting, often to
-units of one day or less. The Development Team self-organizes to undertake the work in the
-Sprint Backlog, both during Sprint Planning and as needed throughout the Sprint.
-The Product Owner can help to clarify the selected Product Backlog items and make trade-offs.
-If the Development Team determines it has too much or too little work, it may renegotiate the
-selected Product Backlog items with the Product Owner. The Development Team may also invite
-other people to attend to provide technical or domain advice.
-By the end of the Sprint Planning, the Development Team should be able to explain to the
-Product Owner and Scrum Master how it intends to work as a self-organizing team to
-accomplish the Sprint Goal and create the anticipated Increment.
+### Sprint Planning
 
-Sprint Goal
-The Sprint Goal is an objective set for the Sprint that can be met through the implementation of
-Product Backlog. It provides guidance to the Development Team on why it is building the
-Increment. It is created during the Sprint Planning meeting. The Sprint Goal gives the
-Development Team some flexibility regarding the functionality implemented within the Sprint.
-The selected Product Backlog items deliver one coherent function, which can be the Sprint Goal.
-The Sprint Goal can be any other coherence that causes the Development Team to work
-together rather than on separate initiatives.
-As the Development Team works, it keeps the Sprint Goal in mind. In order to satisfy the Sprint
-Goal, it implements functionality and technology. If the work turns out to be different than 
-the Development Team expected, they collaborate with the Product Owner to negotiate the 
-scope of Sprint Backlog within the Sprint. 
+Sprint Planning initiates the Sprint by laying out the work to be performed for the Sprint. This resulting plan is created by the collaborative work of the entire Scrum Team.
 
-Daily Scrum
-The Daily Scrum is a 15-minute time-boxed event for the Development Team. The Daily Scrum is
-held every day of the Sprint. At it, the Development Team plans work for the next 24 hours. This
-optimizes team collaboration and performance by inspecting the work since the last Daily Scrum
-and forecasting upcoming Sprint work. The Daily Scrum is held at the same time and place each
-day to reduce complexity.
-The Development Team uses the Daily Scrum to inspect progress toward the Sprint Goal and to
-inspect how progress is trending toward completing the work in the Sprint Backlog. The Daily
-Scrum optimizes the probability that the Development Team will meet the Sprint Goal. Every
-day, the Development Team should understand how it intends to work together as a selforganizing
-team to accomplish the Sprint Goal and create the anticipated Increment by the end
-of the Sprint.
-The structure of the meeting is set by the Development Team and can be conducted in different
-ways if it focuses on progress toward the Sprint Goal. Some Development Teams will use
-questions, some will be more discussion based. Here is an example of what might be used:
-- What did I do yesterday that helped the Development Team meet the Sprint Goal?
-- What will I do today to help the Development Team meet the Sprint Goal?
-- Do I see any impediment that prevents me or the Development Team from meeting the
-Sprint Goal?
-The Development Team or team members often meet immediately after the Daily Scrum for
-detailed discussions, or to adapt, or replan, the rest of the Sprint’s work.
-The Scrum Master ensures that the Development Team has the meeting, but the Development
-Team is responsible for conducting the Daily Scrum. The Scrum Master teaches the
-Development Team to keep the Daily Scrum within the 15-minute time-box.
-The Daily Scrum is an internal meeting for the Development Team. If others are present, the
-Scrum Master ensures that they do not disrupt the meeting.
-Daily Scrums improve communications, eliminate other meetings, identify impediments to
-development for removal, highlight and promote quick decision-making, and improve the
-Development Team’s level of knowledge. This is a key inspect and adapt meeting.
-Sprint Review
-A Sprint Review is held at the end of the Sprint to inspect the Increment and adapt the Product
-Backlog if needed. During the Sprint Review, the Scrum Team and stakeholders collaborate
-about what was done in the Sprint. Based on that and any changes to the Product Backlog
-during the Sprint, attendees collaborate on the next things that could be done to optimize value.
-This is an informal meeting, not a status meeting, and the presentation of the Increment is
-intended to elicit feedback and foster collaboration.
-This is at most a four-hour meeting for one-month Sprints. For shorter Sprints, the event is
-usually shorter. The Scrum Master ensures that the event takes place and that attendees
-understand its purpose. The Scrum Master teaches everyone involved to keep it within the timebox.
-The Sprint Review includes the following elements:
-- Attendees include the Scrum Team and key stakeholders invited by the Product Owner;
-- The Product Owner explains what Product Backlog items have been “Done” and what has
-not been “Done”;
-- The Development Team discusses what went well during the Sprint, what problems it ran
-into, and how those problems were solved;
-- The Development Team demonstrates the work that it has “Done” and answers questions
-about the Increment;
-- The Product Owner discusses the Product Backlog as it stands. He or she projects likely
-target and delivery dates based on progress to date (if needed);
-- The entire group collaborates on what to do next, so that the Sprint Review provides
-valuable input to subsequent Sprint Planning;
-- Review of how the marketplace or potential use of the product might have changed what is
-the most valuable thing to do next; and,
-- Review of the timeline, budget, potential capabilities, and marketplace for the next
-anticipated releases of functionality or capability of the product.
-The result of the Sprint Review is a revised Product Backlog that defines the probable Product
-Backlog items for the next Sprint. The Product Backlog may also be adjusted overall to meet new
-opportunities.
+The Product Owner ensures that attendees are prepared to discuss the most important Product Backlog items and how they map to the Product Goal. The Scrum Team may also invite other people to attend Sprint Planning to provide advice.
 
-Sprint Retrospective
-The Sprint Retrospective is an opportunity for the Scrum Team to inspect itself and create a plan
-for improvements to be enacted during the next Sprint.
-The Sprint Retrospective occurs after the Sprint Review and prior to the next Sprint Planning.
-This is at most a three-hour meeting for one-month Sprints. For shorter Sprints, the event is
-usually shorter. The Scrum Master ensures that the event takes place and that attendants
-understand its purpose.
-The Scrum Master ensures that the meeting is positive and productive. The Scrum Master
-teaches all to keep it within the time-box. The Scrum Master participates as a peer team
-member in the meeting from the accountability over the Scrum process.
-The purpose of the Sprint Retrospective is to:
-- Inspect how the last Sprint went with regards to people, relationships, process, and tools;
-- Identify and order the major items that went well and potential improvements; and,
-- Create a plan for implementing improvements to the way the Scrum Team does its work.
-The Scrum Master encourages the Scrum Team to improve, within the Scrum process
-framework, its development process and practices to make it more effective and enjoyable for
-the next Sprint. During each Sprint Retrospective, the Scrum Team plans ways to increase
-product quality by improving work processes or adapting the definition of “Done”, if appropriate
-and not in conflict with product or organizational standards.
-By the end of the Sprint Retrospective, the Scrum Team should have identified improvements
-that it will implement in the next Sprint. Implementing these improvements in the next Sprint is
-the adaptation to the inspection of the Scrum Team itself. Although improvements may be
-implemented at any time, the Sprint Retrospective provides a formal opportunity to focus on
-inspection and adaptation.
+Sprint Planning addresses the following topics:
 
-Scrum Artifacts
-Scrum’s artifacts represent work or value to provide transparency and opportunities for
-inspection and adaptation. Artifacts defined by Scrum are specifically designed to maximize
-transparency of key information so that everybody has the same understanding of the artifact.
+#### Topic One: Why is this Sprint valuable?
 
-Product Backlog
-The Product Backlog is an ordered list of everything that is known to be needed in the product.
-It is the single source of requirements for any changes to be made to the product. The Product
-Owner is responsible for the Product Backlog, including its content, availability, and ordering.
-A Product Backlog is never complete. The earliest development of it lays out the initially known
-and best-understood requirements. The Product Backlog evolves as the product and the
-environment in which it will be used evolves. The Product Backlog is dynamic; it constantly
-changes to identify what the product needs to be appropriate, competitive, and useful. If a
-product exists, its Product Backlog also exists.
-The Product Backlog lists all features, functions, requirements, enhancements, and fixes that
-constitute the changes to be made to the product in future releases. Product Backlog items have
-the attributes of a description, order, estimate, and value.
-Product Backlog items often include test descriptions that will prove its completeness when “Done.”
-As a product is used and gains value, and the marketplace provides feedback, the Product
-Backlog becomes a larger and more exhaustive list. Requirements never stop changing, so a
-Product Backlog is a living artifact. Changes in business requirements, market conditions, or
-technology may cause changes in the Product Backlog.
-Multiple Scrum Teams often work together on the same product. One Product Backlog is used
-to describe the upcoming work on the product. A Product Backlog attribute that groups items
-may then be employed.
+The Product Owner proposes how the product could increase its value and utility in the current Sprint. The whole Scrum Team then collaborates to define a Sprint Goal that communicates why the Sprint is valuable to stakeholders. The Sprint Goal must be finalized prior to the end of Sprint Planning.
 
-Product Backlog refinement is the act of adding detail, estimates, and order to items in the
-Product Backlog. This is an ongoing process in which the Product Owner and the Development
-Team collaborate on the details of Product Backlog items. During Product Backlog refinement,
-items are reviewed and revised. The Scrum Team decides how and when refinement is done.
-Refinement usually consumes no more than 10% of the capacity of the Development Team.
-However, Product Backlog items can be updated at any time by the Product Owner or at the
-Product Owner’s discretion.
-Higher ordered Product Backlog items are usually clearer and more detailed than lower ordered
-ones. More precise estimates are made based on the greater clarity and increased detail; the
-lower the order, the less detail. Product Backlog items that will occupy the Development Team
-for the upcoming Sprint are refined so that any one item can reasonably be “Done” within the
-Sprint time-box. Product Backlog items that can be “Done” by the Development Team within
-one Sprint are deemed “Ready” for selection in a Sprint Planning. Product Backlog items usually
-acquire this degree of transparency through the above described refining activities.
-The Development Team is responsible for all estimates. The Product Owner may influence the
-Development Team by helping it understand and select trade-offs, but the people who will
-perform the work make the final estimate.
-Monitoring Progress Toward Goals
-At any point in time, the total work remaining to reach a goal can be summed. The Product
-Owner tracks this total work remaining at least every Sprint Review. The Product Owner
-compares this amount with work remaining at previous Sprint Reviews to assess progress
-toward completing projected work by the desired time for the goal. This information is made
-transparent to all stakeholders.
-Various projective practices upon trending have been used to forecast progress, like burndowns, burn-ups, or cumulative flows. These have proven useful. However, these do not replace
-the importance of empiricism. In complex environments, what will happen is unknown. Only
-what has already happened may be used for forward-looking decision-making.
+#### Topic Two: What can be Done this Sprint?
 
-Sprint Backlog
-The Sprint Backlog is the set of Product Backlog items selected for the Sprint, plus a plan for
-delivering the product Increment and realizing the Sprint Goal. The Sprint Backlog is a forecast
-by the Development Team about what functionality will be in the next Increment and the work
-needed to deliver that functionality into a “Done” Increment.
-The Sprint Backlog makes visible all the work that the Development Team identifies as necessary
-to meet the Sprint Goal. 
-To ensure continuous improvement, it includes at least one high
-priority process improvement identified in the previous Retrospective meeting.
-The Sprint Backlog is a plan with enough detail that changes in progress can be understood in
-the Daily Scrum. The Development Team modifies the Sprint Backlog throughout the Sprint, and
-the Sprint Backlog emerges during the Sprint. This emergence occurs as the Development Team
-works through the plan and learns more about the work needed to achieve the Sprint Goal.
-As new work is required, the Development Team adds it to the Sprint Backlog. As work is
-performed or completed, the estimated remaining work is updated. When elements of the plan
-are deemed unnecessary, they are removed. Only the Development Team can change its Sprint
-Backlog during a Sprint. The Sprint Backlog is a highly visible, real-time picture of the work that
-the Development Team plans to accomplish during the Sprint, and it belongs solely to the
-Development Team.
-Monitoring Sprint Progress
-At any point in time in a Sprint, the total work remaining in the Sprint Backlog can be summed.
-The Development Team tracks this total work remaining at least for every Daily Scrum to project
-the likelihood of achieving the Sprint Goal. By tracking the remaining work throughout the
-Sprint, the Development Team can manage its progress.
-Increment
-The Increment is the sum of all the Product Backlog items completed during a Sprint and the
-value of the increments of all previous Sprints. At the end of a Sprint, the new Increment must
-be “Done,” which means it must be in useable condition and meet the Scrum Team’s definition
-of “Done.” An increment is a body of inspectable, done work that supports empiricism at the
-end of the Sprint. The increment is a step toward a vision or goal. The increment must be in
-useable condition regardless of whether the Product Owner decides to release it.
-Artifact Transparency
-Scrum relies on transparency. Decisions to optimize value and control risk are made based on
-the perceived state of the artifacts. To the extent that transparency is complete, these decisions
-have a sound basis. To the extent that the artifacts are incompletely transparent, these
-decisions can be flawed, value may diminish and risk may increase.
-The Scrum Master must work with the Product Owner, Development Team, and other involved
-parties to understand if the artifacts are completely transparent. There are practices for coping
-with incomplete transparency; the Scrum Master must help everyone apply the most
-appropriate practices in the absence of complete transparency. A Scrum Master can detect
-incomplete transparency by inspecting the artifacts, sensing patterns, listening closely to what is
-being said, and detecting differences between expected and real results.
-The Scrum Master’s job is to work with the Scrum Team and the organization to increase the
-transparency of the artifacts. This work usually involves learning, convincing, and change.
-Transparency doesn’t occur overnight, but is a path.
-Definition of “Done”
-When a Product Backlog item or an Increment is described as “Done”, everyone must
-understand what “Done” means. Although this may vary significantly per Scrum Team, members
-must have a shared understanding of what it means for work to be complete, to ensure
-transparency. This is the definition of “Done” for the Scrum Team and is used to assess when
-work is complete on the product Increment.
-The same definition guides the Development Team in knowing how many Product Backlog items
-it can select during a Sprint Planning. The purpose of each Sprint is to deliver Increments of
-potentially releasable functionality that adhere to the Scrum Team’s current definition of
-“Done.”
-Development Teams deliver an Increment of product functionality every Sprint. This Increment
-is useable, so a Product Owner may choose to immediately release it. If the definition of "Done"
-for an increment is part of the conventions, standards or guidelines of the development
-organization, all Scrum Teams must follow it as a minimum. If "Done" for an increment is not a 
-convention of the development organization, the
-Development Team of the Scrum Team must define a definition of “Done” appropriate for the
-product. If there are multiple Scrum Teams working on the system or product release, the
-Development Teams on all the Scrum Teams must mutually define the definition of “Done.”
-Each Increment is additive to all prior Increments and thoroughly tested, ensuring that all
-Increments work together.
-As Scrum Teams mature, it is expected that their definitions of “Done” will expand to include
-more stringent criteria for higher quality. New definitions, as used, may uncover work to be
-done in previously “Done” increments. Any one product or system should have a definition of
-“Done” that is a standard for any work done on it.
+Through discussion with the Product Owner, the Developers select items from the Product Backlog to include in the current Sprint. The Scrum Team may refine these items during this process, which increases understanding and confidence.
 
-End Note
-Scrum is free and offered in this Guide. Scrum’s roles, events, artifacts, and rules are immutable
-and although implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists
-only in its entirety and functions well as a container for other techniques, methodologies, and
-practices.
-Acknowledgements
-People
-Of the thousands of people who have contributed to Scrum, we should single out those who
-were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John
-Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them
-worked together. Many others contributed in the ensuing years and without their help Scrum
-would not be refined as it is today.
-History
-Ken Schwaber and Jeff Sutherland worked on Scrum until 1995, when they co-presented Scrum
-at the OOPSLA Conference in 1995. This presentation essentially documented the learning that
-Ken and Jeff gained over the previous few years, and made public the first formal definition of
-Scrum.
-The history of Scrum is described elsewhere. To honor the first places where it was tried and
-refined, we recognize Individual, Inc., Newspage, Fidelity Investments, and IDX (now GE
-Medical).
-The Scrum Guide documents Scrum as developed, evolved, and sustained for 20-plus years by
-Jeff Sutherland and Ken Schwaber. Other sources provide you with patterns, processes, and
-insights that complement the Scrum framework. These may increase productivity, value,
-creativity, and satisfaction with the results.
+Selecting how much can be completed within a Sprint may be challenging. However, the more the Developers know about their past performance, their upcoming capacity, and their Definition of Done, the more confident they will be in their Sprint forecasts.
+
+#### Topic Three: How will the chosen work get done?
+
+For each selected Product Backlog item, the Developers plan the work necessary to create an Increment that meets the Definition of Done. This is often done by decomposing Product Backlog items into smaller work items of one day or less. How this is done is at the sole discretion of the Developers. No one else tells them how to turn Product Backlog items into Increments of value.
+
+The Sprint Goal, the Product Backlog items selected for the Sprint, plus the plan for delivering them are together referred to as the Sprint Backlog.
+
+Sprint Planning is timeboxed to a maximum of eight hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
+
+### Daily Scrum
+
+The purpose of the Daily Scrum is to inspect progress toward the Sprint Goal and adapt the Sprint Backlog as necessary, adjusting the upcoming planned work.
+
+The Daily Scrum is a 15-minute event for the Developers of the Scrum Team. To reduce complexity, it is held at the same time and place every working day of the Sprint. If the Product Owner or Scrum Master are actively working on items in the Sprint Backlog, they participate as Developers.
+
+The Developers can select whatever structure and techniques they want, as long as their Daily Scrum focuses on progress toward the Sprint Goal and produces an actionable plan for the next day of work. This creates focus and improves self-management.
+
+Daily Scrums improve communications, identify impediments, promote quick decision-making, and consequently eliminate the need for other meetings.
+
+The Daily Scrum is not the only time Developers are allowed to adjust their plan. They often meet throughout the day for more detailed discussions about adapting or re-planning the rest of the Sprint’s work.
+
+### Sprint Review
+
+The purpose of the Sprint Review is to inspect the outcome of the Sprint and determine future adaptations. The Scrum Team presents the results of their work to key stakeholders and progress toward the Product Goal is discussed.
+
+During the event, the Scrum Team and stakeholders review what was accomplished in the Sprint and what has changed in their environment. Based on this information, attendees collaborate on what to do next. The Product Backlog may also be adjusted to meet new opportunities. The Sprint Review is a working session and the Scrum Team should avoid limiting it to a presentation.
+
+The Sprint Review is the second to last event of the Sprint and is timeboxed to a maximum of four hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
+
+### Sprint Retrospective
+
+The purpose of the Sprint Retrospective is to plan ways to increase quality and effectiveness.
+
+The Scrum Team inspects how the last Sprint went with regards to individuals, interactions, processes, tools, and their Definition of Done. Inspected elements often vary with the domain of work. Assumptions that led them astray are identified and their origins explored. The Scrum Team discusses what went well during the Sprint, what problems it encountered, and how those problems were (or were not) solved.
+
+The Scrum Team identifies the most helpful changes to improve its effectiveness. The most impactful improvements are addressed as soon as possible. They may even be added to the Sprint Backlog for the next Sprint.
+
+The Sprint Retrospective concludes the Sprint. It is timeboxed to a maximum of three hours for a one-month Sprint. For shorter Sprints, the event is usually shorter.
+
+## Scrum Artifacts
+
+Scrum’s artifacts represent work or value. They are designed to maximize transparency of key information. Thus, everyone inspecting them has the same basis for adaptation.
+
+Each artifact contains a commitment to ensure it provides information that enhances transparency and focus against which progress can be measured:
+
+For the Product Backlog it is the Product Goal.
+
+For the Sprint Backlog it is the Sprint Goal.
+
+For the Increment it is the Definition of Done.
+
+These commitments exist to reinforce empiricism and the Scrum values for the Scrum Team and their stakeholders.
+
+### Product Backlog
+
+The Product Backlog is an emergent, ordered list of what is needed to improve the product. It is the single source of work undertaken by the Scrum Team.
+
+Product Backlog items that can be Done by the Scrum Team within one Sprint are deemed ready for selection in a Sprint Planning event. They usually acquire this degree of transparency after refining activities. Product Backlog refinement is the act of breaking down and further defining Product Backlog items into smaller more precise items. This is an ongoing activity to add details, such as a description, order, and size. Attributes often vary with the domain of work.
+
+The Developers who will be doing the work are responsible for the sizing. The Product Owner may influence the Developers by helping them understand and select trade-offs.
+
+#### Commitment: Product Goal
+
+The Product Goal describes a future state of the product which can serve as a target for the Scrum Team to plan against. The Product Goal is in the Product Backlog. The rest of the Product Backlog emerges to define “what” will fulfill the Product Goal.
+
+> A product is a vehicle to deliver value. It has a clear boundary, known stakeholders, well-defined users or customers. A product could be a service, a physical product, or something more abstract.
+
+The Product Goal is the long-term objective for the Scrum Team. They must fulfill (or abandon) one objective before taking on the next.
+
+### Sprint Backlog
+
+The Sprint Backlog is composed of the Sprint Goal (why), the set of Product Backlog items selected for the Sprint (what), as well as an actionable plan for delivering the Increment (how).
+
+The Sprint Backlog is a plan by and for the Developers. It is a highly visible, real-time picture of the work that the Developers plan to accomplish during the Sprint in order to achieve the Sprint Goal. Consequently, the Sprint Backlog is updated throughout the Sprint as more is learned. It should have enough detail that they can inspect their progress in the Daily Scrum.
+
+#### Commitment: Sprint Goal
+
+The Sprint Goal is the single objective for the Sprint. Although the Sprint Goal is a commitment by the Developers, it provides flexibility in terms of the exact work needed to achieve it. The Sprint Goal also creates coherence and focus, encouraging the Scrum Team to work together rather than on separate initiatives.
+
+The Sprint Goal is created during the Sprint Planning event and then added to the Sprint Backlog. As the Developers work during the Sprint, they keep the Sprint Goal in mind. If the work turns out to be different than they expected, they collaborate with the Product Owner to negotiate the scope of the Sprint Backlog within the Sprint without affecting the Sprint Goal.
+
+### Increment
+
+An Increment is a concrete stepping stone toward the Product Goal. Each Increment is additive to all prior Increments and thoroughly verified, ensuring that all Increments work together. In order to provide value, the Increment must be usable.
+
+Multiple Increments may be created within a Sprint. The sum of the Increments is presented at the Sprint Review thus supporting empiricism. However, an Increment may be delivered to stakeholders prior to the end of the Sprint. The Sprint Review should never be considered a gate to releasing value.
+
+Work cannot be considered part of an Increment unless it meets the Definition of Done.
+
+#### Commitment: Definition of Done
+
+The Definition of Done is a formal description of the state of the Increment when it meets the quality measures required for the product.
+
+The moment a Product Backlog item meets the Definition of Done, an Increment is born.
+
+The Definition of Done creates transparency by providing everyone a shared understanding of what work was completed as part of the Increment. If a Product Backlog item does not meet the Definition of Done, it cannot be released or even presented at the Sprint Review. Instead, it returns to the Product Backlog for future consideration.
+
+If the Definition of Done for an increment is part of the standards of the organization, all Scrum Teams must follow it as a minimum. If it is not an organizational standard, the Scrum Team must create a Definition of Done appropriate for the product.
+
+The Developers are required to conform to the Definition of Done. If there are multiple Scrum Teams working together on a product, they must mutually define and comply with the same Definition of Done.
+
+## End Note
+
+Scrum is free and offered in this Guide. The Scrum framework, as outlined herein, is immutable. While implementing only parts of Scrum is possible, the result is not Scrum. Scrum exists only in its entirety and functions well as a container for other techniques, methodologies, and practices.
+
+### Acknowledgements
+
+#### People
+
+Of the thousands of people who have contributed to Scrum, we should single out those who were instrumental at the start: Jeff Sutherland worked with Jeff McKenna and John Scumniotales, and Ken Schwaber worked with Mike Smith and Chris Martin, and all of them worked together. Many others contributed in the ensuing years and without their help Scrum would not be refined as it is today.
+
+#### Scrum Guide History
+
+Ken Schwaber and Jeff Sutherland first co-presented Scrum at the OOPSLA Conference in 1995. It essentially documented the learning that Ken and Jeff gained over the previous few years and made public the first formal definition of Scrum.
+
+The Scrum Guide documents Scrum as developed, evolved, and sustained for 30-plus years by Jeff Sutherland and Ken Schwaber. Other sources provide patterns, processes, and insights that complement the Scrum framework. These may increase productivity, value, creativity, and satisfaction with the results.
+
+The complete history of Scrum is described elsewhere. To honor the first places where it was tried and proven, we recognize Individual Inc., Newspage, Fidelity Investments, and IDX (now GE Medical).
+
+© 2020 Ken Schwaber and Jeff Sutherland This publication is offered for license under the Attribution Share-Alike license of Creative Commons, accessible at https://creativecommons.org/licenses/by-sa/4.0/legalcode and also described in summary form at https://creativecommons.org/licenses/by-sa/4.0/. By utilizing this Scrum Guide, you acknowledge and agree that you have read and agree to be bound by the terms of the Attribution Share-Alike license of Creative Commons.


### PR DESCRIPTION
@peitor - Here's a version of the November 2020 Scrum Guide, formatted for Markdown support to match the headings, bullets, and text formatting of the official guide.